### PR TITLE
add das_watchdog: a realtime watchdog

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ To see a description of one of the listed options (in this case `enable`):
 
   `nixos-option musnix.rtirq.enable`
 
+## Other Options
+
+`musnix.das_watchdog.enable`
+* **Description:** If enabled, start the [das_watchdog](https://github.com/kmatheussen/das_watchdog) service.  This service will ensure that a realtime process won't hang the machine.
+* **Default value:** `true` if `musnix.kernel.realtime.enable = true`, otherwise `false`
+
 ## More Information
 * http://wiki.linuxaudio.org/wiki/system_configuration
 * http://wiki.linuxaudio.org/wiki/system_configuration#rtirq

--- a/default.nix
+++ b/default.nix
@@ -3,6 +3,7 @@
 { imports =
     [ ./modules/base.nix
       ./modules/kernel.nix
+      ./modules/other.nix
       ./modules/rtirq.nix
     ];
 }

--- a/modules/other.nix
+++ b/modules/other.nix
@@ -1,0 +1,20 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  options.musnix = {
+    das_watchdog.enable = mkOption {
+      type = types.bool;
+      default = config.musnix.kernel.realtime;
+      description = ''
+        If enabled, start the das_watchdog service.  This service will ensure
+        that a realtime process won't hang the machine.
+      '';
+    };
+  };
+
+  config = {
+    services.das_watchdog.enable = config.musnix.das_watchdog.enable;
+  };
+}


### PR DESCRIPTION
Do you agree this belongs in musnix?
It makes sure your machine doesn't lock up even if there are RT processes taking up all the resources.

(after https://github.com/NixOS/nixpkgs/pull/7987 gets merged, that is)