### PR TITLE
Refactor kernel.nix, add 3.18.17-rt14 and 4.0.5-rt4 kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ Add the following to your `configuration.nix`:
 * **Description:** If enabled, this option will apply the [`CONFIG_PREEMPT_RT`](https://rt.wiki.kernel.org/index.php/Main_Page) patch to the kernel.
 * **Default value:** `false`
 
+`musnix.kernel.packages`
+* **Description:** This option allows you to select the real-time kernel used by musnix.
+* **Default value:** `pkgs.linuxPackages_3_18_rt`
+* Available packages:
+  * `pkgs.linuxPackages_3_14_rt`
+  * `pkgs.linuxPackages_3_18_rt`
+  * `pkgs.linuxPackages_4_0_rt`
+
 `musnix.kernel.latencytop`
 * **NOTE:** Enabling this option will rebuild your kernel.
 * **NOTE:** This option is only intended to be used for diagnostic purposes, and may cause other issues.

--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -22,6 +22,7 @@ let
   kernelConfigRealtime = ''
     PREEMPT_RT_FULL y
     PREEMPT y
+    LOCK_TORTURE_TEST n
   '';
 
   musnixRealtimeKernelExtraConfig =
@@ -76,7 +77,7 @@ in {
       '';
     };
     kernel.packages = mkOption {
-      default = pkgs.linuxPackages_3_14_rt;
+      default = pkgs.linuxPackages_3_18_rt;
       description = ''
         FIXME: Kernel packages
       '';
@@ -103,7 +104,25 @@ in {
         extraConfig   = musnixRealtimeKernelExtraConfig;
       };
 
+      linux_3_18_rt   = stdenv.lib.makeOverridable (import ../pkgs/os-specific/linux/kernel/linux-3.18-rt.nix) {
+        inherit fetchurl stdenv perl buildLinux;
+        kernelPatches = [ pkgs.kernelPatches.bridge_stp_helper
+                          realtimePatches.realtimePatch_3_18
+                        ];
+        extraConfig   = musnixRealtimeKernelExtraConfig;
+      };
+
+      linux_4_0_rt    = stdenv.lib.makeOverridable (import ../pkgs/os-specific/linux/kernel/linux-4.0-rt.nix) {
+        inherit fetchurl stdenv perl buildLinux;
+        kernelPatches = [ pkgs.kernelPatches.bridge_stp_helper
+                          realtimePatches.realtimePatch_4_0
+                        ];
+        extraConfig   = musnixRealtimeKernelExtraConfig;
+      };
+
       linuxPackages_3_14_rt = recurseIntoAttrs (linuxPackagesFor linux_3_14_rt linuxPackages_3_14_rt);
+      linuxPackages_3_18_rt = recurseIntoAttrs (linuxPackagesFor linux_3_18_rt linuxPackages_3_18_rt);
+      linuxPackages_4_0_rt  = recurseIntoAttrs (linuxPackagesFor linux_4_0_rt  linuxPackages_4_0_rt);
       linuxPackages_opt     = recurseIntoAttrs (linuxPackagesFor linux_opt     linuxPackages_opt);
 
       realtimePatches = callPackage ../pkgs/os-specific/linux/kernel/patches.nix { };

--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -18,30 +18,25 @@ let
     HPET_TIMER y
     TREE_RCU_TRACE n
   '';
-  # PREEMPT y is set below
 
   kernelConfigRealtime = ''
     PREEMPT_RT_FULL y
     PREEMPT y
   '';
 
-  kernelSources = rec {
-    version = "3.14.36";
-    src = pkgs.fetchurl {
-      url = "mirror://kernel/linux/kernel/v3.x/linux-${version}.tar.xz";
-      sha256 = "03pl303z3vvldc3hamlrq77mcy66nsqdfk7yi43nzyrnmrby3l0r";
-    };
-  };
+  musnixRealtimeKernelExtraConfig =
+    kernelConfigRealtime
+    + optionalString cfg.kernel.optimize kernelConfigOptimize
+    + optionalString cfg.kernel.latencytop kernelConfigLatencyTOP;
 
-  realtimePatch = rec {
-    version = "rt34";
-    kversion = "3.14.36";
-    name = "rt-${kversion}-${version}";
-    patch = pkgs.fetchurl {
-      url = "https://www.kernel.org/pub/linux/kernel/projects/rt/3.14/older/patch-${kversion}-${version}.patch.xz";
-      sha256 = "098nnnbh989rci2x2zmsjdj5h6ivgz4yp3qa30494rbay6v8faiv";
-    };
-  };
+  musnixStandardKernelExtraConfig =
+    if cfg.kernel.optimize
+      then "PREEMPT y\n"
+           + kernelConfigOptimize
+           + optionalString cfg.kernel.latencytop kernelConfigLatencyTOP
+      else if cfg.kernel.latencytop
+        then kernelConfigLatencyTOP
+        else "";
 
 in {
   options.musnix = {
@@ -80,33 +75,39 @@ in {
         patch to the kernel.
       '';
     };
+    kernel.packages = mkOption {
+      default = pkgs.linuxPackages_3_14_rt;
+      description = ''
+        FIXME: Kernel packages
+      '';
+    };
   };
 
   config = {
     boot.kernelPackages =
-      let
-        rtKernel =
-          pkgs.linux_3_14.override {
-            argsOverride = kernelSources;
-            kernelPatches = [ realtimePatch ];
-            extraConfig = kernelConfigRealtime
-                          + optionalString cfg.kernel.optimize kernelConfigOptimize
-                          + optionalString cfg.kernel.latencytop kernelConfigLatencyTOP;
-          };
-        stdKernel =
-          if cfg.kernel.optimize
-            then pkgs.linux.override {
-              extraConfig = "PREEMPT y\n"
-                            + kernelConfigOptimize
-                            + optionalString cfg.kernel.latencytop kernelConfigLatencyTOP;
-            }
-            else if cfg.kernel.latencytop
-              then pkgs.linux.override { extraConfig = kernelConfigLatencyTOP; }
-              else pkgs.linux;
-        musnixKernel =
-          if cfg.kernel.realtime then rtKernel else stdKernel;
-        musnixKernelPackages =
-          pkgs.recurseIntoAttrs (pkgs.linuxPackagesFor musnixKernel musnixKernelPackages);
-      in musnixKernelPackages;
+      if cfg.kernel.realtime
+        then cfg.kernel.packages
+        else pkgs.linuxPackages_opt;
+
+    nixpkgs.config.packageOverrides = pkgs: with pkgs; rec {
+
+      linux_opt       = pkgs.linux.override {
+        extraConfig   = musnixStandardKernelExtraConfig;
+      };
+
+      linux_3_14_rt   = stdenv.lib.makeOverridable (import ../pkgs/os-specific/linux/kernel/linux-3.14-rt.nix) {
+        inherit fetchurl stdenv perl buildLinux;
+        kernelPatches = [ pkgs.kernelPatches.bridge_stp_helper
+                          realtimePatches.realtimePatch_3_14
+                        ];
+        extraConfig   = musnixRealtimeKernelExtraConfig;
+      };
+
+      linuxPackages_3_14_rt = recurseIntoAttrs (linuxPackagesFor linux_3_14_rt linuxPackages_3_14_rt);
+      linuxPackages_opt     = recurseIntoAttrs (linuxPackagesFor linux_opt     linuxPackages_opt);
+
+      realtimePatches = callPackage ../pkgs/os-specific/linux/kernel/patches.nix { };
+
+    };
   };
 }

--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -79,7 +79,12 @@ in {
     kernel.packages = mkOption {
       default = pkgs.linuxPackages_3_18_rt;
       description = ''
-        FIXME: Kernel packages
+        This option allows you to select the real-time kernel used by musnix.
+
+        Available packages:
+        * pkgs.linuxPackages_3_14_rt
+        * pkgs.linuxPackages_3_18_rt
+        * pkgs.linuxPackages_4_0_rt
       '';
     };
   };

--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -92,32 +92,32 @@ in {
 
     nixpkgs.config.packageOverrides = pkgs: with pkgs; rec {
 
-      linux_opt       = pkgs.linux.override {
-        extraConfig   = musnixStandardKernelExtraConfig;
-      };
-
-      linux_3_14_rt   = stdenv.lib.makeOverridable (import ../pkgs/os-specific/linux/kernel/linux-3.14-rt.nix) {
+      linux_3_14_rt   = makeOverridable (import ../pkgs/os-specific/linux/kernel/linux-3.14-rt.nix) {
         inherit fetchurl stdenv perl buildLinux;
-        kernelPatches = [ pkgs.kernelPatches.bridge_stp_helper
+        kernelPatches = [ kernelPatches.bridge_stp_helper
                           realtimePatches.realtimePatch_3_14
                         ];
         extraConfig   = musnixRealtimeKernelExtraConfig;
       };
 
-      linux_3_18_rt   = stdenv.lib.makeOverridable (import ../pkgs/os-specific/linux/kernel/linux-3.18-rt.nix) {
+      linux_3_18_rt   = makeOverridable (import ../pkgs/os-specific/linux/kernel/linux-3.18-rt.nix) {
         inherit fetchurl stdenv perl buildLinux;
-        kernelPatches = [ pkgs.kernelPatches.bridge_stp_helper
+        kernelPatches = [ kernelPatches.bridge_stp_helper
                           realtimePatches.realtimePatch_3_18
                         ];
         extraConfig   = musnixRealtimeKernelExtraConfig;
       };
 
-      linux_4_0_rt    = stdenv.lib.makeOverridable (import ../pkgs/os-specific/linux/kernel/linux-4.0-rt.nix) {
+      linux_4_0_rt    = makeOverridable (import ../pkgs/os-specific/linux/kernel/linux-4.0-rt.nix) {
         inherit fetchurl stdenv perl buildLinux;
-        kernelPatches = [ pkgs.kernelPatches.bridge_stp_helper
+        kernelPatches = [ kernelPatches.bridge_stp_helper
                           realtimePatches.realtimePatch_4_0
                         ];
         extraConfig   = musnixRealtimeKernelExtraConfig;
+      };
+
+      linux_opt       = linux.override {
+        extraConfig   = musnixStandardKernelExtraConfig;
       };
 
       linuxPackages_3_14_rt = recurseIntoAttrs (linuxPackagesFor linux_3_14_rt linuxPackages_3_14_rt);

--- a/pkgs/os-specific/linux/kernel/linux-3.14-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.14-rt.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, ... } @ args:
 
 import <nixpkgs/pkgs/os-specific/linux/kernel/generic.nix> (args // rec {
-  version = "3.14.36";
+  version = "3.14.46";
   extraMeta.branch = "3.14";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v3.x/linux-${version}.tar.xz";
-    sha256 = "03pl303z3vvldc3hamlrq77mcy66nsqdfk7yi43nzyrnmrby3l0r";
+    sha256 = "1ran8fi1ldc89x3gpxwkkfl64mln4sl0rq5bbl8imlca5nljmzkb";
   };
 
   features.iwlwifi = true;

--- a/pkgs/os-specific/linux/kernel/linux-3.14-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.14-rt.nix
@@ -1,0 +1,17 @@
+{ stdenv, fetchurl, ... } @ args:
+
+import <nixpkgs/pkgs/os-specific/linux/kernel/generic.nix> (args // rec {
+  version = "3.14.36";
+  extraMeta.branch = "3.14";
+
+  src = fetchurl {
+    url = "mirror://kernel/linux/kernel/v3.x/linux-${version}.tar.xz";
+    sha256 = "03pl303z3vvldc3hamlrq77mcy66nsqdfk7yi43nzyrnmrby3l0r";
+  };
+
+  features.iwlwifi = true;
+  features.efiBootStub = true;
+  features.needsCifsUtils = true;
+  features.canDisableNetfilterConntrackHelpers = true;
+  features.netfilterRPFilter = true;
+} // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-3.18-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.18-rt.nix
@@ -1,0 +1,17 @@
+{ stdenv, fetchurl, ... } @ args:
+
+import <nixpkgs/pkgs/os-specific/linux/kernel/generic.nix> (args // rec {
+  version = "3.18.17";
+  extraMeta.branch = "3.18";
+
+  src = fetchurl {
+    url = "mirror://kernel/linux/kernel/v3.x/linux-${version}.tar.xz";
+    sha256 = "08512kqvy91jh26jld2h3d9xq3wsfbyylzawjgn75x4r5li6y5ha";
+  };
+
+  features.iwlwifi = true;
+  features.efiBootStub = true;
+  features.needsCifsUtils = true;
+  features.canDisableNetfilterConntrackHelpers = true;
+  features.netfilterRPFilter = true;
+} // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-4.0-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.0-rt.nix
@@ -1,0 +1,17 @@
+{ stdenv, fetchurl, ... } @ args:
+
+import <nixpkgs/pkgs/os-specific/linux/kernel/generic.nix> (args // rec {
+  version = "4.0.5";
+  extraMeta.branch = "4.0";
+
+  src = fetchurl {
+    url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
+    sha256 = "1l9kxicadn980wrypi2qm3nx12g513acvryq58m7a0xjdf6ksjz2";
+  };
+
+  features.iwlwifi = true;
+  features.efiBootStub = true;
+  features.needsCifsUtils = true;
+  features.canDisableNetfilterConntrackHelpers = true;
+  features.netfilterRPFilter = true;
+} // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -24,4 +24,18 @@ in rec {
       sha256 = "1ckba761y38x6s6w4r1c5xns7d0m824ldh8lhxxm1a0s485k573n";
     };
 
+  realtimePatch_3_18 = realtimePatch
+    { branch = "3.18";
+      kversion = "3.18.17";
+      version = "rt14";
+      sha256 = "063ah6a47b48xz38bk4l3mhl8n7lqyc4h1w9ii5rngd20lzgm4qy";
+    };
+
+  realtimePatch_4_0 = realtimePatch
+    { branch = "4.0";
+      kversion = "4.0.5";
+      version = "rt4";
+      sha256 = "1pyjymq7mmj3fkkh9sv2ipr31xs219jnmj6k0lyipiygm5n1c0wm";
+    };
+
  }

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl }:
+
+let
+
+  realtimePatch =
+    { branch
+    , kversion
+    , version
+    , url ? "https://www.kernel.org/pub/linux/kernel/projects/rt/${branch}/patch-${kversion}-${version}.patch.xz"
+    , sha256
+    }:
+    { name  = "rt-${kversion}-${version}";
+      patch = fetchurl {
+        inherit url sha256;
+      };
+    };
+
+in rec {
+
+  realtimePatch_3_14 = realtimePatch
+    { branch = "3.14";
+      kversion = "3.14.36";
+      version = "rt34";
+      url = "https://www.kernel.org/pub/linux/kernel/projects/rt/3.14/older/patch-3.14.36-rt34.patch.xz";
+      sha256 = "098nnnbh989rci2x2zmsjdj5h6ivgz4yp3qa30494rbay6v8faiv";
+    };
+
+ }

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -19,10 +19,9 @@ in rec {
 
   realtimePatch_3_14 = realtimePatch
     { branch = "3.14";
-      kversion = "3.14.36";
-      version = "rt34";
-      url = "https://www.kernel.org/pub/linux/kernel/projects/rt/3.14/older/patch-3.14.36-rt34.patch.xz";
-      sha256 = "098nnnbh989rci2x2zmsjdj5h6ivgz4yp3qa30494rbay6v8faiv";
+      kversion = "3.14.46";
+      version = "rt46";
+      sha256 = "1ckba761y38x6s6w4r1c5xns7d0m824ldh8lhxxm1a0s485k573n";
     };
 
  }


### PR DESCRIPTION
Opening this to track progress...

Important changes:
* Users will be able to choose from several available real-time kernels.  This is done by setting `musnix.kernel.packages` to one of the following packages:  
  * `pkgs.linuxPackages_3_14_rt`
  * `pkgs.linuxPackages_3_18_rt` (default)
  * `pkgs.linuxPackages_4_0_rt`
* For real-time kernels, rather than applying the `CONFIG_PREEMPT_RT` patches using overrides, the patches are now directly applied to three new kernel derivations.   The patch expressions have also been moved to a separate file.  This approach is similar to what is used in [nixpkgs](https://github.com/NixOS/nixpkgs/tree/master/pkgs/os-specific/linux/kernel), and facilitates moving some of this work there when the time comes.  
  * At that point, we'd probably add something like: 

    ```
    features.realtime = true;
    ```
    to each real-time kernel expression, and the kernel config flags would be moved from `extraConfig`, where they are now, to an 
    ```
    ${optionalString features.realtime ''
    
    ...

    ''}
    ``` 
    clause in [`common-config.nix`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/kernel/common-config.nix), etc.  
  * As in this PR, we would need separate kernel expressions in nixpkgs,  because the patches need to stay pinned to their particular kernel versions.  

* Similarly, the directory structure of `pkgs` now mirrors the relevant [slice](https://github.com/NixOS/nixpkgs/tree/master/pkgs/os-specific/linux) of nixpkgs.