### PR TITLE
kernel: append rt patch revision to version

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-3.14-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.14-rt.nix
@@ -1,11 +1,13 @@
 { stdenv, fetchurl, ... } @ args:
 
 import <nixpkgs/pkgs/os-specific/linux/kernel/generic.nix> (args // rec {
-  version = "3.14.48";
+  kversion = "3.14.48";
+  pversion = "rt48";
+  version = "${kversion}-${pversion}";
   extraMeta.branch = "3.14";
 
   src = fetchurl {
-    url = "mirror://kernel/linux/kernel/v3.x/linux-${version}.tar.xz";
+    url = "mirror://kernel/linux/kernel/v3.x/linux-${kversion}.tar.xz";
     sha256 = "098a7kjfw4jf0f7h6z57f2719jfz3y3jjlcd8y6d95xvhy7xxyw9";
   };
 

--- a/pkgs/os-specific/linux/kernel/linux-3.18-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.18-rt.nix
@@ -1,11 +1,13 @@
 { stdenv, fetchurl, ... } @ args:
 
 import <nixpkgs/pkgs/os-specific/linux/kernel/generic.nix> (args // rec {
-  version = "3.18.18";
+  kversion = "3.18.18";
+  pversion = "rt15";
+  version = "${kversion}-${pversion}";
   extraMeta.branch = "3.18";
 
   src = fetchurl {
-    url = "mirror://kernel/linux/kernel/v3.x/linux-${version}.tar.xz";
+    url = "mirror://kernel/linux/kernel/v3.x/linux-${kversion}.tar.xz";
     sha256 = "1fcd4xfnywwb3grdvcnf39njwzb40v10rnzagxqmancsaqy253jv";
   };
 

--- a/pkgs/os-specific/linux/kernel/linux-4.0-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.0-rt.nix
@@ -1,11 +1,13 @@
 { stdenv, fetchurl, ... } @ args:
 
 import <nixpkgs/pkgs/os-specific/linux/kernel/generic.nix> (args // rec {
-  version = "4.0.8";
+  kversion = "4.0.8";
+  pversion = "rt6";
+  version = "${kversion}-${pversion}";
   extraMeta.branch = "4.0";
 
   src = fetchurl {
-    url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
+    url = "mirror://kernel/linux/kernel/v4.x/linux-${kversion}.tar.xz";
     sha256 = "1cggqi5kdan818xw5g5wmapcsf501f5m9bympsy6a2cpphknfdmn";
   };
 


### PR DESCRIPTION
Fixes the following build error:

```
make[1]: Leaving directory '/tmp/nix-build-linux-3.18.17.drv-0/build'
unlink: cannot unlink '/nix/store/bjmsfxxi82i0gxq3i8hzi4nj6nsz61hk-linux-3.18.17/lib/modules/3.18.17/build': No such file or directory
builder for ‘/nix/store/6w9w916z5gl835hsz2m3p4dq9njlagd3-linux-3.18.17.drv’ failed with exit code 1
cannot build derivation ‘/nix/store/d534vj66389wv3zsy6pqyj9xxpcb616p-nixos-15.07pre66213.9d5508d.drv’: 1 dependencies couldn't be built
error: build of ‘/nix/store/d534vj66389wv3zsy6pqyj9xxpcb616p-nixos-15.07pre66213.9d5508d.drv’ failed
```
