### PR TITLE
kernel: fix rt patch url

### DIFF
--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -6,7 +6,7 @@ let
     { branch
     , kversion
     , pversion
-    , url ? "https://www.kernel.org/pub/linux/kernel/projects/rt/${branch}/patch-${kversion}-${pversion}.patch.xz"
+    , url ? "https://www.kernel.org/pub/linux/kernel/projects/rt/${branch}/older/patch-${kversion}-${pversion}.patch.xz"
     , sha256
     }:
     { name  = "rt-${kversion}-${pversion}";


### PR DESCRIPTION
Use a stable URL for the patches.

e.g. https://www.kernel.org/pub/linux/kernel/projects/rt/4.6/
contains only the latest patch
while https://www.kernel.org/pub/linux/kernel/projects/rt/4.6/older/
contains all patches including the latest