### PR TITLE
update for 17.03

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,20 @@ Add the following to your `configuration.nix`:
 
 ```
 
-The following sections contain information about the various configuration options.
+Later sections of this document contain information about the various configuration options.
+
+### A note about NixOS versions
+
+Users who are on NixOS 16.09 or earlier should use the [`pre-17.03`](https://github.com/musnix/musnix/tree/pre-17.03) branch.
+
+You can check your NixOS version with the `nixos-version` command.
+
+You can clone the `pre-17.03` branch directly with the following command:
+```
+git clone --branch=pre-17.03 https://github.com/musnix/musnix.git
+```
+
+See [#42](https://github.com/musnix/musnix/pull/42) for more information about this change.
 
 ## Base Options
 

--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -94,6 +94,7 @@ in {
   };
 
   config = mkIf (cfg.kernel.latencytop || cfg.kernel.optimize || cfg.kernel.realtime) {
+
     boot.kernelPackages =
       if cfg.kernel.realtime
         then cfg.kernel.packages
@@ -101,48 +102,42 @@ in {
 
     nixpkgs.config.packageOverrides = pkgs: with pkgs; rec {
 
-      linux_3_14_rt = makeOverridable (import ../pkgs/os-specific/linux/kernel/linux-3.14-rt.nix) {
-        inherit fetchurl stdenv perl buildLinux;
+      linux_3_14_rt = callPackage ../pkgs/os-specific/linux/kernel/linux-3.14-rt.nix {
         kernelPatches = [ kernelPatches.bridge_stp_helper
                           realtimePatches.realtimePatch_3_14
                         ];
         extraConfig   = musnixRealtimeKernelExtraConfig;
       };
 
-      linux_3_18_rt = makeOverridable (import ../pkgs/os-specific/linux/kernel/linux-3.18-rt.nix) {
-        inherit fetchurl stdenv perl buildLinux;
+      linux_3_18_rt = callPackage ../pkgs/os-specific/linux/kernel/linux-3.18-rt.nix {
         kernelPatches = [ kernelPatches.bridge_stp_helper
                           realtimePatches.realtimePatch_3_18
                         ];
         extraConfig   = musnixRealtimeKernelExtraConfig;
       };
 
-      linux_4_1_rt = makeOverridable (import ../pkgs/os-specific/linux/kernel/linux-4.1-rt.nix) {
-        inherit fetchurl stdenv perl buildLinux;
+      linux_4_1_rt = callPackage ../pkgs/os-specific/linux/kernel/linux-4.1-rt.nix {
         kernelPatches = [ kernelPatches.bridge_stp_helper
                           realtimePatches.realtimePatch_4_1
                         ];
         extraConfig   = musnixRealtimeKernelExtraConfig;
       };
 
-      linux_4_4_rt = makeOverridable (import ../pkgs/os-specific/linux/kernel/linux-4.4-rt.nix) {
-        inherit fetchurl stdenv perl buildLinux;
+      linux_4_4_rt = callPackage ../pkgs/os-specific/linux/kernel/linux-4.4-rt.nix {
         kernelPatches = [ kernelPatches.bridge_stp_helper
                           realtimePatches.realtimePatch_4_4
                         ];
         extraConfig   = musnixRealtimeKernelExtraConfig;
       };
 
-      linux_4_6_rt = makeOverridable (import ../pkgs/os-specific/linux/kernel/linux-4.6-rt.nix) {
-        inherit fetchurl stdenv perl buildLinux;
+      linux_4_6_rt = callPackage ../pkgs/os-specific/linux/kernel/linux-4.6-rt.nix {
         kernelPatches = [ kernelPatches.bridge_stp_helper
                           realtimePatches.realtimePatch_4_6
                         ];
         extraConfig   = musnixRealtimeKernelExtraConfig;
       };
 
-      linux_4_8_rt = makeOverridable (import ../pkgs/os-specific/linux/kernel/linux-4.8-rt.nix) {
-        inherit fetchurl stdenv perl buildLinux;
+      linux_4_8_rt = callPackage ../pkgs/os-specific/linux/kernel/linux-4.8-rt.nix {
         kernelPatches = [ kernelPatches.bridge_stp_helper
                           kernelPatches.modinst_arg_list_too_long
                           realtimePatches.realtimePatch_4_8
@@ -154,18 +149,17 @@ in {
         extraConfig = musnixStandardKernelExtraConfig;
       };
 
-      linuxPackages_3_14_rt = recurseIntoAttrs (linuxPackagesFor linux_3_14_rt linuxPackages_3_14_rt);
-      linuxPackages_3_18_rt = recurseIntoAttrs (linuxPackagesFor linux_3_18_rt linuxPackages_3_18_rt);
-      linuxPackages_4_1_rt  = recurseIntoAttrs (linuxPackagesFor linux_4_1_rt  linuxPackages_4_1_rt);
-      linuxPackages_4_4_rt  = recurseIntoAttrs (linuxPackagesFor linux_4_4_rt  linuxPackages_4_4_rt);
-      linuxPackages_4_6_rt  = recurseIntoAttrs (linuxPackagesFor linux_4_6_rt  linuxPackages_4_6_rt);
-      linuxPackages_4_8_rt  = recurseIntoAttrs (linuxPackagesFor linux_4_8_rt  linuxPackages_4_8_rt);
-      linuxPackages_opt     = recurseIntoAttrs (linuxPackagesFor linux_opt     linuxPackages_opt);
+      linuxPackages_3_14_rt = recurseIntoAttrs (linuxPackagesFor linux_3_14_rt);
+      linuxPackages_3_18_rt = recurseIntoAttrs (linuxPackagesFor linux_3_18_rt);
+      linuxPackages_4_1_rt  = recurseIntoAttrs (linuxPackagesFor linux_4_1_rt);
+      linuxPackages_4_4_rt  = recurseIntoAttrs (linuxPackagesFor linux_4_4_rt);
+      linuxPackages_4_6_rt  = recurseIntoAttrs (linuxPackagesFor linux_4_6_rt);
+      linuxPackages_4_8_rt  = recurseIntoAttrs (linuxPackagesFor linux_4_8_rt);
+      linuxPackages_opt     = recurseIntoAttrs (linuxPackagesFor linux_opt);
 
       linuxPackages_latest_rt = linuxPackages_4_8_rt;
 
       realtimePatches = callPackage ../pkgs/os-specific/linux/kernel/patches.nix { };
-
     };
   };
 }

--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -17,6 +17,7 @@ let
     DEFAULT_IOSCHED deadline
     HPET_TIMER y
     TREE_RCU_TRACE n
+    RT_GROUP_SCHED? n
   '';
 
   kernelConfigRealtime = ''

--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -14,7 +14,7 @@ let
   kernelConfigOptimize = ''
     IOSCHED_DEADLINE y
     DEFAULT_DEADLINE y
-    DEFAULT_IOSCHED "deadline"
+    DEFAULT_IOSCHED deadline
     HPET_TIMER y
     TREE_RCU_TRACE n
   '';

--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -146,6 +146,14 @@ in {
         extraConfig   = musnixRealtimeKernelExtraConfig;
       };
 
+      linux_4_9_rt = callPackage ../pkgs/os-specific/linux/kernel/linux-4.9-rt.nix {
+        kernelPatches = [ kernelPatches.bridge_stp_helper
+                          kernelPatches.modinst_arg_list_too_long
+                          realtimePatches.realtimePatch_4_9
+                        ];
+        extraConfig   = musnixRealtimeKernelExtraConfig;
+      };
+
       linux_opt = linux.override {
         extraConfig = musnixStandardKernelExtraConfig;
       };
@@ -156,9 +164,10 @@ in {
       linuxPackages_4_4_rt  = recurseIntoAttrs (linuxPackagesFor linux_4_4_rt);
       linuxPackages_4_6_rt  = recurseIntoAttrs (linuxPackagesFor linux_4_6_rt);
       linuxPackages_4_8_rt  = recurseIntoAttrs (linuxPackagesFor linux_4_8_rt);
+      linuxPackages_4_9_rt  = recurseIntoAttrs (linuxPackagesFor linux_4_9_rt);
       linuxPackages_opt     = recurseIntoAttrs (linuxPackagesFor linux_opt);
 
-      linuxPackages_latest_rt = linuxPackages_4_8_rt;
+      linuxPackages_latest_rt = linuxPackages_4_9_rt;
 
       realtimePatches = callPackage ../pkgs/os-specific/linux/kernel/patches.nix { };
     };

--- a/pkgs/os-specific/linux/kernel/linux-4.9-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.9-rt.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, perl, buildLinux, ... } @ args:
+
+import <nixpkgs/pkgs/os-specific/linux/kernel/generic.nix> (args // rec {
+  kversion = "4.9.18";
+  pversion = "rt14";
+  version = "${kversion}-${pversion}";
+  extraMeta.branch = "4.9";
+
+  src = fetchurl {
+    url = "mirror://kernel/linux/kernel/v4.x/linux-${kversion}.tar.xz";
+    sha256 = "1lb18b29ykia9v2ryj1w6chwh19hmv6ynfjhl9p66rsnm09fl3m1";
+  };
+
+  kernelPatches = args.kernelPatches;
+
+  features.iwlwifi = true;
+  features.efiBootStub = true;
+  features.needsCifsUtils = true;
+  features.netfilterRPFilter = true;
+} // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -58,4 +58,11 @@ in rec {
       pversion = "rt10";
       sha256 = "1zsrjx1sljn7wsr4yvxq4cjmvzl25c3myqvps1ksv1qjcwx3bg21";
     };
+
+  realtimePatch_4_9 = realtimePatch rec
+    { branch = "4.9";
+      kversion = "4.9.18";
+      pversion = "rt14";
+      sha256 = "0wr5nzapj9b3z9qwjfx9mafwh5kjn1vrr4s04fs6143vxrafaiw2";
+    };
 }


### PR DESCRIPTION
17.03 is out!

17.03 introduces changes in the kernel configuration machinery, so **I'm proposing that we maintain a [`pre-17.03`](https://github.com/musnix/musnix/tree/pre-17.03) branch for users who wish to stay on 16.09 or earlier**.  I'd probably continue to focus my maintenance efforts on `master` but would gladly accept PRs against the `pre-17.03` branch from people who wanted to keep things current for earlier versions.

Does this sound good?

cc @magnetophon @erlandsona @tg-x @pngwjpgh @peterhoeg 
(or anyone else who might have a horse in this race)

Ref: #39 