### PR TITLE
override RT_GROUP_SCHED explicitly in rt config

### DIFF
--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -23,6 +23,7 @@ let
   kernelConfigRealtime = ''
     PREEMPT_RT_FULL y
     PREEMPT y
+    RT_GROUP_SCHED? n
   '';
 
   musnixRealtimeKernelExtraConfig =


### PR DESCRIPTION
In `common-config.nix`, the `RT_GROUP_SCHED` flag is set explicitly to `n` in a non-optional manner.

See here:
https://github.com/NixOS/nixpkgs/blob/7cdd12e4e977a39c570442a0728d217ff4ca177a/pkgs/os-specific/linux/kernel/common-config.nix#L466

The rt patch set includes a patch that makes this flag depend on `PREEMPT_RT_FULL` not being set to `y`.  In other words, when we set `PREEMPT_RT_FULL` to `y`, we effectively remove this flag and our ability to set it.

However, this causes an rt kernel build to fail for us because the default kernel configuration has explicitly set `RT_GROUP_SCHED` to `n`, and in our case, because of the aforementioned dependency and the fact that we are setting `PREEMPT_RT_FULL` to `y`, this flag no longer "exists" nor is it configurable.

By overriding the `RT_GROUP_SCHED` flag in an optional manner, the build will no longer fail.  Instead, it will merely warn us that such a setting no longer exists.

Fixes #57