### PR TITLE
rtirq: update download url

### DIFF
--- a/pkgs/os-specific/linux/rtirq/default.nix
+++ b/pkgs/os-specific/linux/rtirq/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "20180209";
 
   src = fetchurl {
-    url = "http://www.rncbc.org/jack/${name}-${version}.tar.gz";
+    url = "http://www.rncbc.org/archive/${name}-${version}.tar.gz";
     sha256 = "09phbn8cq5m39dz3mijrsb3p4vfp7c4ngsk1mvs8qm09n7zpqrfs";
   };
 


### PR DESCRIPTION
Hello, looks like rncbc.org changes the download url for rtirq tarball?

The original url didn't work for me, so I found a new download url at http://www.rncbc.org/drupal/node/1886