### PR TITLE
Linux 4.19.15-rt12 -> Linux 4.19.23-rt14 and latest rtirq

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-4.19-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.19-rt.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, hostPlatform, buildPackages, perl, buildLinux, ... } @ args:
 
 buildLinux (args // rec {
-  kversion = "4.19.15";
-  pversion = "rt12";
+  kversion = "4.19.23";
+  pversion = "rt14";
   version = "${kversion}-${pversion}";
   extraMeta.branch = "4.19";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${kversion}.tar.xz";
-    sha256 = "0v9nbkxc017ydcah5q0yhrlq1f7awc33m6w4gpif2f0wvxfimxkq";
+    sha256 = "02hkiz5vlx2qhyi1hxar9d1cr2gfnrpjdrjjkh83yzxci9kjb6rd";
   };
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -82,8 +82,8 @@ in rec {
 
   realtimePatch_4_19 = realtimePatch
     { branch = "4.19";
-      kversion = "4.19.15";
-    pversion = "rt12";
-    sha256 = "0v0w35fjkxpw6rh4mn00g35nqdwgvd9n1srsy23n7cbdxjm5ldnj";
+      kversion = "4.19.23";
+    pversion = "rt14";
+    sha256 = "081ni6kq082mrbmbk436nhyi1anm4jlrpc1b4v7rwyypn3fa5yw3";
   };
 }

--- a/pkgs/os-specific/linux/rtirq/default.nix
+++ b/pkgs/os-specific/linux/rtirq/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "rtirq";
-  version = "20180209";
+  version = "20190129";
 
   src = fetchurl {
     url = "http://www.rncbc.org/archive/${name}-${version}.tar.gz";
-    sha256 = "09phbn8cq5m39dz3mijrsb3p4vfp7c4ngsk1mvs8qm09n7zpqrfs";
+    sha256 = "1qclzpldvx6s7vr8ff2bv2jwp3pxdbanbph33hyicrjg8sy6q4ka";
   };
 
   phases = [ "unpackPhase" "patchPhase" "installPhase" ];


### PR DESCRIPTION
Update Linux kernel to latest RT patchset.
Musnix refers to no-longer existing version of rtirq, updated to the latest available.