### PR TITLE
modules/rtirq: update usage of environment.etc

### DIFF
--- a/modules/rtirq.nix
+++ b/modules/rtirq.nix
@@ -82,11 +82,7 @@ in {
 
   config = mkIf cfg.enable {
     environment.systemPackages = [ rtirq ];
-    environment.etc =
-      [ { source = rtirqConf;
-          target = "rtirq.conf";
-        }
-      ];
+    environment.etc."rtirq.conf".source = rtirqConf;
     systemd.services.rtirq = {
       description = "IRQ thread tuning for realtime kernels";
       after = [ "multi-user.target" "sound.target" ];


### PR DESCRIPTION
The current usage triggers the warning from
https://github.com/NixOS/nixpkgs/pull/63103/commits/03309899:

    trace: warning: In file /home/uj/nix/musnix/modules/rtirq.nix
    a list is being assigned to the option config.environment.etc.
    This will soon be an error as type loaOf is deprecated.
    See https://github.com/NixOS/nixpkgs/pull/63103 for more information.
    Do
      environment.etc =
        { rtirq.conf = {...}; }
    instead of
      environment.etc =
        [ { target = "rtirq.conf"; ...} ]