### PR TITLE
Kernels: update 4.19 and add 5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,10 @@ sudo -i nix-channel --update musnix
   * `pkgs.linuxPackages_4_18_rt`
   * `pkgs.linuxPackages_4_19_rt`
   * `pkgs.linuxPackages_5_0_rt`
+  * `pkgs.linuxPackages_5_4_rt`
 
   or:
-  * `pkgs.linuxPackages_latest_rt` (currently `pkgs.linuxPackages_5_0_rt`)
+  * `pkgs.linuxPackages_latest_rt` (currently `pkgs.linuxPackages_5_4_rt`)
 
 `musnix.kernel.latencytop`
 * **NOTE:** Enabling this option will rebuild your kernel.

--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -79,8 +79,9 @@ in {
         * pkgs.linuxPackages_4_18_rt
         * pkgs.linuxPackages_4_19_rt
         * pkgs.linuxPackages_5_0_rt
+        * pkgs.linuxPackages_5_4_rt
         or:
-        * pkgs.linuxPackages_latest_rt (currently pkgs.linuxPackages_5_0_rt)
+        * pkgs.linuxPackages_latest_rt (currently pkgs.linuxPackages_5_4_rt)
       '';
     };
   };
@@ -175,6 +176,13 @@ in {
                         ];
         structuredExtraConfig = realtimeConfig "5.0";
       };
+      linux_5_4_rt = callPackage ../pkgs/os-specific/linux/kernel/linux-5.4-rt.nix {
+        kernelPatches = [ kernelPatches.bridge_stp_helper
+                          # kernelPatches.modinst_arg_list_too_long
+                          realtimePatches.realtimePatch_5_4
+                        ];
+        structuredExtraConfig = realtimeConfig "5.4";
+      };
 
 
       linux_opt = linux.override {
@@ -192,9 +200,10 @@ in {
       linuxPackages_4_18_rt = recurseIntoAttrs (linuxPackagesFor linux_4_18_rt);
       linuxPackages_4_19_rt = recurseIntoAttrs (linuxPackagesFor linux_4_19_rt);
       linuxPackages_5_0_rt  = recurseIntoAttrs (linuxPackagesFor linux_5_0_rt);
+      linuxPackages_5_4_rt  = recurseIntoAttrs (linuxPackagesFor linux_5_4_rt);
       linuxPackages_opt     = recurseIntoAttrs (linuxPackagesFor linux_opt);
 
-      linuxPackages_latest_rt = linuxPackages_5_0_rt;
+      linuxPackages_latest_rt = linuxPackages_5_4_rt;
 
       realtimePatches = callPackage ../pkgs/os-specific/linux/kernel/patches.nix { };
     };

--- a/modules/rtirq.nix
+++ b/modules/rtirq.nix
@@ -82,11 +82,7 @@ in {
 
   config = mkIf cfg.enable {
     environment.systemPackages = [ rtirq ];
-    environment.etc =
-      [ { source = rtirqConf;
-          target = "rtirq.conf";
-        }
-      ];
+    environment.etc."rtirq.conf".source = rtirqConf;
     systemd.services.rtirq = {
       description = "IRQ thread tuning for realtime kernels";
       after = [ "multi-user.target" "sound.target" ];

--- a/pkgs/os-specific/linux/kernel/linux-4.19-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.19-rt.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, hostPlatform, buildPackages, perl, buildLinux, ... } @ args:
 
 buildLinux (args // rec {
-  kversion = "4.19.31";
-  pversion = "rt18";
+  kversion = "4.19.106";
+  pversion = "rt45";
   version = "${kversion}-${pversion}";
   extraMeta.branch = "4.19";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${kversion}.tar.xz";
-    sha256 = "02r822zhs1xcjy6jpf9fv0h4br47drd3xssxapr2b45y8anr1aks";
+    sha256 = "1nlwgs15mc3hlfhqw95pz7wisg8yshzrxzzq2a0y30mjm5vbvj33";
   };
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-5.4-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.4-rt.nix
@@ -1,0 +1,13 @@
+{ stdenv, fetchurl, hostPlatform, buildPackages, perl, buildLinux, ... } @ args:
+
+buildLinux (args // rec {
+  kversion = "5.4.26";
+  pversion = "rt17";
+  version = "${kversion}-${pversion}";
+  extraMeta.branch = "5.4";
+
+  src = fetchurl {
+    url = "mirror://kernel/linux/kernel/v5.x/linux-${kversion}.tar.xz";
+    sha256 = "1bqdiw4pjzwm7pxml2dl09bj85ijs82rq788c58681zgmvs796k6";
+  };
+} // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -82,9 +82,9 @@ in rec {
 
   realtimePatch_4_19 = realtimePatch
     { branch = "4.19";
-      kversion = "4.19.31";
-    pversion = "rt18";
-    sha256 = "0mir7k8iz5qhk3irj6sryvppsr76by734lis6zhqg5hl88am9d6f";
+      kversion = "4.19.106";
+    pversion = "rt45";
+    sha256 = "11717gixa1jhc78s507s7x5wh2kqjcnqs7m885as82chm5bfv4gx";
   };
 
   realtimePatch_5_0 = realtimePatch

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -93,4 +93,11 @@ in rec {
     pversion = "rt11";
     sha256 = "005krk67w8742nqv63b8mnjkssw6db3k19x1jdfr26rgdcq9azbi";
   };
+
+  realtimePatch_5_4 = realtimePatch
+    { branch = "5.4";
+      kversion = "5.4.26";
+      pversion = "rt17";
+      sha256 = "110mlhfa3hdswkrcc4sxly6gh303p7d917r69cc8y9s97ia9dsdh";
+    };
 }


### PR DESCRIPTION
Thanks to @orivej we can build all kernels again: https://github.com/musnix/musnix/pull/106.
When it is merged, these updates are possible.
