### PR TITLE
convert to overlay

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,4 +6,8 @@
       ./modules/other.nix
       ./modules/rtirq.nix
     ];
+
+  nixpkgs.overlays = [
+    (import ./overlay.nix)
+  ];
 }

--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -1,34 +1,10 @@
 { config, lib, pkgs, ... }:
 
-with lib.kernel;
 with lib;
 
 let
 
   cfg = config.musnix;
-
-  standardConfig = version: with (lib.kernel.whenHelpers version);
-    optionalAttrs cfg.kernel.latencytop {
-      LATENCYTOP = yes;
-      SCHEDSTATS = yes;
-    } //
-    optionalAttrs cfg.kernel.optimize {
-      PREEMPT = yes;
-      # DEADLINE was renamed to MT_DEADLINE and enabled by default.
-      IOSCHED_DEADLINE = whenOlder "5" yes;
-      DEFAULT_DEADLINE = whenOlder "5" yes;
-      DEFAULT_IOSCHED = whenOlder "5" (freeform "deadline");
-    };
-
-  realtimeConfig = version: with (lib.kernel.whenHelpers version);
-    (standardConfig version) // {
-      PREEMPT = whenOlder "5.4" yes; # PREEMPT_RT deselects it.
-      PREEMPT_RT_FULL = whenOlder "5.4" yes; # Renamed to PREEMPT_RT when merged into the mainline.
-      EXPERT = whenAtLeast "5.4" yes; # PREEMPT_RT depends on it (in kernel/Kconfig.preempt).
-      PREEMPT_RT = whenAtLeast "5.4" yes;
-      PREEMPT_VOLUNTARY = lib.mkForce no; # PREEMPT_RT deselects it.
-      RT_GROUP_SCHED = lib.mkForce (option no); # Removed by sched-disable-rt-group-sched-on-rt.patch.
-    };
 
 in {
   options.musnix = {
@@ -98,126 +74,5 @@ in {
         then cfg.kernel.packages
         else pkgs.linuxPackages_opt;
 
-    nixpkgs.config.packageOverrides = pkgs: with pkgs; rec {
-
-      linux_3_18_rt = callPackage ../pkgs/os-specific/linux/kernel/linux-3.18-rt.nix {
-        kernelPatches = [ kernelPatches.bridge_stp_helper
-                          realtimePatches.realtimePatch_3_18
-                        ];
-        structuredExtraConfig = realtimeConfig "3.18";
-      };
-
-      linux_4_1_rt = callPackage ../pkgs/os-specific/linux/kernel/linux-4.1-rt.nix {
-        kernelPatches = [ kernelPatches.bridge_stp_helper
-                          realtimePatches.realtimePatch_4_1
-                        ];
-        structuredExtraConfig = realtimeConfig "4.1";
-      };
-
-      linux_4_4_rt = callPackage ../pkgs/os-specific/linux/kernel/linux-4.4-rt.nix {
-        kernelPatches = [ kernelPatches.bridge_stp_helper
-                          realtimePatches.realtimePatch_4_4
-                        ];
-        structuredExtraConfig = realtimeConfig "4.4";
-      };
-
-      linux_4_9_rt = callPackage ../pkgs/os-specific/linux/kernel/linux-4.9-rt.nix {
-        kernelPatches = [ kernelPatches.bridge_stp_helper
-                          kernelPatches.modinst_arg_list_too_long
-                          realtimePatches.realtimePatch_4_9
-                        ];
-        structuredExtraConfig = realtimeConfig "4.9";
-      };
-
-      linux_4_11_rt = callPackage ../pkgs/os-specific/linux/kernel/linux-4.11-rt.nix {
-        kernelPatches = [ kernelPatches.bridge_stp_helper
-                          kernelPatches.modinst_arg_list_too_long
-                          realtimePatches.realtimePatch_4_11
-                        ];
-        structuredExtraConfig = realtimeConfig "4.11";
-      };
-
-      linux_4_13_rt = callPackage ../pkgs/os-specific/linux/kernel/linux-4.13-rt.nix {
-        kernelPatches = [ kernelPatches.bridge_stp_helper
-                          kernelPatches.modinst_arg_list_too_long
-                          realtimePatches.realtimePatch_4_13
-                        ];
-        structuredExtraConfig = realtimeConfig "4.13";
-      };
-
-      linux_4_14_rt = callPackage ../pkgs/os-specific/linux/kernel/linux-4.14-rt.nix {
-        kernelPatches = [ kernelPatches.bridge_stp_helper
-                          kernelPatches.modinst_arg_list_too_long
-                          realtimePatches.realtimePatch_4_14
-                        ];
-        structuredExtraConfig = realtimeConfig "4.14";
-      };
-
-      linux_4_16_rt = callPackage ../pkgs/os-specific/linux/kernel/linux-4.16-rt.nix {
-        kernelPatches = [ kernelPatches.bridge_stp_helper
-                          kernelPatches.modinst_arg_list_too_long
-                          realtimePatches.realtimePatch_4_16
-                        ];
-        structuredExtraConfig = realtimeConfig "4.16";
-      };
-      linux_4_18_rt = callPackage ../pkgs/os-specific/linux/kernel/linux-4.18-rt.nix {
-        kernelPatches = [ kernelPatches.bridge_stp_helper
-                          kernelPatches.modinst_arg_list_too_long
-                          realtimePatches.realtimePatch_4_18
-                        ];
-        structuredExtraConfig = realtimeConfig "4.18";
-      };
-      linux_4_19_rt = callPackage ../pkgs/os-specific/linux/kernel/linux-4.19-rt.nix {
-        kernelPatches = [ kernelPatches.bridge_stp_helper
-                          kernelPatches.modinst_arg_list_too_long
-                          realtimePatches.realtimePatch_4_19
-                        ];
-        structuredExtraConfig = realtimeConfig "4.19";
-      };
-      linux_5_0_rt = callPackage ../pkgs/os-specific/linux/kernel/linux-5.0-rt.nix {
-        kernelPatches = [ kernelPatches.bridge_stp_helper
-                          kernelPatches.modinst_arg_list_too_long
-                          realtimePatches.realtimePatch_5_0
-                        ];
-        structuredExtraConfig = realtimeConfig "5.0";
-      };
-      linux_5_4_rt = callPackage ../pkgs/os-specific/linux/kernel/linux-5.4-rt.nix {
-        kernelPatches = [ kernelPatches.bridge_stp_helper
-                          realtimePatches.realtimePatch_5_4
-                        ];
-        structuredExtraConfig = realtimeConfig "5.4";
-      };
-      linux_5_6_rt = callPackage ../pkgs/os-specific/linux/kernel/linux-5.6-rt.nix {
-        kernelPatches = [ kernelPatches.bridge_stp_helper
-                          realtimePatches.realtimePatch_5_6
-                        ];
-        structuredExtraConfig = realtimeConfig "5.6";
-      };
-
-
-
-      linux_opt = linux.override {
-        structuredExtraConfig = standardConfig linux.version;
-      };
-
-      linuxPackages_3_18_rt = recurseIntoAttrs (linuxPackagesFor linux_3_18_rt);
-      linuxPackages_4_1_rt  = recurseIntoAttrs (linuxPackagesFor linux_4_1_rt);
-      linuxPackages_4_4_rt  = recurseIntoAttrs (linuxPackagesFor linux_4_4_rt);
-      linuxPackages_4_9_rt  = recurseIntoAttrs (linuxPackagesFor linux_4_9_rt);
-      linuxPackages_4_11_rt = recurseIntoAttrs (linuxPackagesFor linux_4_11_rt);
-      linuxPackages_4_13_rt = recurseIntoAttrs (linuxPackagesFor linux_4_13_rt);
-      linuxPackages_4_14_rt = recurseIntoAttrs (linuxPackagesFor linux_4_14_rt);
-      linuxPackages_4_16_rt = recurseIntoAttrs (linuxPackagesFor linux_4_16_rt);
-      linuxPackages_4_18_rt = recurseIntoAttrs (linuxPackagesFor linux_4_18_rt);
-      linuxPackages_4_19_rt = recurseIntoAttrs (linuxPackagesFor linux_4_19_rt);
-      linuxPackages_5_0_rt  = recurseIntoAttrs (linuxPackagesFor linux_5_0_rt);
-      linuxPackages_5_4_rt  = recurseIntoAttrs (linuxPackagesFor linux_5_4_rt);
-      linuxPackages_5_6_rt  = recurseIntoAttrs (linuxPackagesFor linux_5_6_rt);
-      linuxPackages_opt     = recurseIntoAttrs (linuxPackagesFor linux_opt);
-
-      linuxPackages_latest_rt = linuxPackages_5_6_rt;
-
-      realtimePatches = callPackage ../pkgs/os-specific/linux/kernel/patches.nix { };
-    };
   };
 }

--- a/modules/rtirq.nix
+++ b/modules/rtirq.nix
@@ -6,8 +6,6 @@ let
 
   cfg = config.musnix.rtirq;
 
-  rtirq = pkgs.callPackage ../pkgs/os-specific/linux/rtirq/default.nix { };
-
   rtirqConf = pkgs.writeText "rtirq.conf" ''
     # This is a generated file.  Do not edit!
     RTIRQ_NAME_LIST="${cfg.nameList}"
@@ -81,7 +79,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    environment.systemPackages = [ rtirq ];
+    environment.systemPackages = [ pkgs.rtirq ];
     environment.etc."rtirq.conf".source = rtirqConf;
     systemd.services.rtirq = {
       description = "IRQ thread tuning for realtime kernels";
@@ -96,8 +94,8 @@ in {
       serviceConfig = {
         User = "root";
         Type = "oneshot";
-        ExecStart = "${rtirq}/bin/rtirq start";
-        ExecStop = "${rtirq}/bin/rtirq stop";
+        ExecStart = "${pkgs.rtirq}/bin/rtirq start";
+        ExecStop = "${pkgs.rtirq}/bin/rtirq stop";
         RemainAfterExit = true;
       };
     };

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,186 @@
+self: super:
+
+let
+
+  inherit (super) lib callPackage linuxPackagesFor;
+
+  cfg = super.config.musnix or {
+    kernel.latencytop = false;
+    kernel.optimize = false;
+  };
+
+  standardConfig = {
+    version,
+    enableLatencytop ? cfg.kernel.latencytop,
+    enableOptimization ? cfg.kernel.optimize
+  }:
+    with (lib.kernel);
+    with (lib.kernel.whenHelpers version);
+    lib.optionalAttrs enableLatencytop {
+      LATENCYTOP = yes;
+      SCHEDSTATS = yes;
+    } //
+    lib.optionalAttrs enableOptimization {
+      PREEMPT = yes;
+      # DEADLINE was renamed to MT_DEADLINE and enabled by default.
+      IOSCHED_DEADLINE = whenOlder "5" yes;
+      DEFAULT_DEADLINE = whenOlder "5" yes;
+      DEFAULT_IOSCHED = whenOlder "5" (freeform "deadline");
+    };
+
+  realtimeConfig = { version, enableLatencytop, enableOptimization }:
+    with (lib.kernel);
+    with (lib.kernel.whenHelpers version);
+    (standardConfig { inherit version enableLatencytop enableOptimization; }) // {
+      PREEMPT = whenOlder "5.4" yes; # PREEMPT_RT deselects it.
+      PREEMPT_RT_FULL = whenOlder "5.4" yes; # Renamed to PREEMPT_RT when merged into the mainline.
+      EXPERT = whenAtLeast "5.4" yes; # PREEMPT_RT depends on it (in kernel/Kconfig.preempt).
+      PREEMPT_RT = whenAtLeast "5.4" yes;
+      PREEMPT_VOLUNTARY = lib.mkForce no; # PREEMPT_RT deselects it.
+      RT_GROUP_SCHED = lib.mkForce (option no); # Removed by sched-disable-rt-group-sched-on-rt.patch.
+    };
+
+in
+with lib;
+{
+
+  buildLinuxRT = {
+    enableLatencytop ? cfg.kernel.latencytop,
+    enableOptimization ? cfg.kernel.optimize,
+    ...
+  }@args: super.buildLinux (args // {
+    structuredExtraConfig = realtimeConfig {
+      inherit enableLatencytop enableOptimization;
+      version = args.extraMeta.branch;
+    };
+  } // (args.argsOverride or {}));
+
+  linux_3_18_rt = callPackage ./pkgs/os-specific/linux/kernel/linux-3.18-rt.nix {
+    kernelPatches = [
+      super.kernelPatches.bridge_stp_helper
+      self.realtimePatches.realtimePatch_3_18
+    ];
+  };
+
+  linux_4_1_rt = callPackage ./pkgs/os-specific/linux/kernel/linux-4.1-rt.nix {
+    kernelPatches = [
+      super.kernelPatches.bridge_stp_helper
+      self.realtimePatches.realtimePatch_4_1
+    ];
+  };
+
+  linux_4_4_rt = callPackage ./pkgs/os-specific/linux/kernel/linux-4.4-rt.nix {
+    kernelPatches = [
+      super.kernelPatches.bridge_stp_helper
+      self.realtimePatches.realtimePatch_4_4
+    ];
+  };
+
+  linux_4_9_rt = callPackage ./pkgs/os-specific/linux/kernel/linux-4.9-rt.nix {
+    kernelPatches = [
+      super.kernelPatches.bridge_stp_helper
+      super.kernelPatches.modinst_arg_list_too_long
+      self.realtimePatches.realtimePatch_4_9
+    ];
+  };
+
+  linux_4_11_rt = callPackage ./pkgs/os-specific/linux/kernel/linux-4.11-rt.nix {
+    kernelPatches = [
+      super.kernelPatches.bridge_stp_helper
+      super.kernelPatches.modinst_arg_list_too_long
+      self.realtimePatches.realtimePatch_4_11
+    ];
+  };
+
+  linux_4_13_rt = callPackage ./pkgs/os-specific/linux/kernel/linux-4.13-rt.nix {
+    kernelPatches = [
+      super.kernelPatches.bridge_stp_helper
+      super.kernelPatches.modinst_arg_list_too_long
+      self.realtimePatches.realtimePatch_4_13
+    ];
+  };
+
+  linux_4_14_rt = callPackage ./pkgs/os-specific/linux/kernel/linux-4.14-rt.nix {
+    kernelPatches = [
+      super.kernelPatches.bridge_stp_helper
+      super.kernelPatches.modinst_arg_list_too_long
+      self.realtimePatches.realtimePatch_4_14
+    ];
+  };
+
+  linux_4_16_rt = callPackage ./pkgs/os-specific/linux/kernel/linux-4.16-rt.nix {
+    kernelPatches = [
+      super.kernelPatches.bridge_stp_helper
+      super.kernelPatches.modinst_arg_list_too_long
+      self.realtimePatches.realtimePatch_4_16
+    ];
+  };
+
+  linux_4_18_rt = callPackage ./pkgs/os-specific/linux/kernel/linux-4.18-rt.nix {
+    kernelPatches = [
+      super.kernelPatches.bridge_stp_helper
+      super.kernelPatches.modinst_arg_list_too_long
+      self.realtimePatches.realtimePatch_4_18
+    ];
+  };
+
+  linux_4_19_rt = callPackage ./pkgs/os-specific/linux/kernel/linux-4.19-rt.nix {
+    kernelPatches = [
+      super.kernelPatches.bridge_stp_helper
+      super.kernelPatches.modinst_arg_list_too_long
+      self.realtimePatches.realtimePatch_4_19
+    ];
+  };
+
+  linux_5_0_rt = callPackage ./pkgs/os-specific/linux/kernel/linux-5.0-rt.nix {
+    kernelPatches = [
+      super.kernelPatches.bridge_stp_helper
+      super.kernelPatches.modinst_arg_list_too_long
+      self.realtimePatches.realtimePatch_5_0
+    ];
+  };
+
+  linux_5_4_rt = callPackage ./pkgs/os-specific/linux/kernel/linux-5.4-rt.nix {
+    kernelPatches = [
+      super.kernelPatches.bridge_stp_helper
+      self.realtimePatches.realtimePatch_5_4
+    ];
+  };
+
+  linux_5_6_rt = callPackage ./pkgs/os-specific/linux/kernel/linux-5.6-rt.nix {
+    kernelPatches = [
+      super.kernelPatches.bridge_stp_helper
+      self.realtimePatches.realtimePatch_5_6
+    ];
+  };
+
+  linux_opt = super.linux.override {
+    structuredExtraConfig = standardConfig { inherit (super.linux) version; };
+  };
+
+  linuxPackages_3_18_rt = recurseIntoAttrs (linuxPackagesFor self.linux_3_18_rt);
+  linuxPackages_4_1_rt  = recurseIntoAttrs (linuxPackagesFor self.linux_4_1_rt);
+  linuxPackages_4_4_rt  = recurseIntoAttrs (linuxPackagesFor self.linux_4_4_rt);
+  linuxPackages_4_9_rt  = recurseIntoAttrs (linuxPackagesFor self.linux_4_9_rt);
+  linuxPackages_4_11_rt = recurseIntoAttrs (linuxPackagesFor self.linux_4_11_rt);
+  linuxPackages_4_13_rt = recurseIntoAttrs (linuxPackagesFor self.linux_4_13_rt);
+  linuxPackages_4_14_rt = recurseIntoAttrs (linuxPackagesFor self.linux_4_14_rt);
+  linuxPackages_4_16_rt = recurseIntoAttrs (linuxPackagesFor self.linux_4_16_rt);
+  linuxPackages_4_18_rt = recurseIntoAttrs (linuxPackagesFor self.linux_4_18_rt);
+  linuxPackages_4_19_rt = recurseIntoAttrs (linuxPackagesFor self.linux_4_19_rt);
+  linuxPackages_5_0_rt  = recurseIntoAttrs (linuxPackagesFor self.linux_5_0_rt);
+  linuxPackages_5_4_rt  = recurseIntoAttrs (linuxPackagesFor self.linux_5_4_rt);
+  linuxPackages_5_6_rt  = recurseIntoAttrs (linuxPackagesFor self.linux_5_6_rt);
+  linuxPackages_opt     = recurseIntoAttrs (linuxPackagesFor self.linux_opt);
+
+  linuxPackages_rt = self.linuxPackages_5_4_rt;
+  linux_rt = self.linuxPackages_rt.kernel;
+
+  linuxPackages_latest_rt = self.linuxPackages_5_6_rt;
+  linux_latest_rt = self.linuxPackages_latest_rt.kernel;
+
+  realtimePatches = callPackage ./pkgs/os-specific/linux/kernel/patches.nix {};
+
+  rtirq = callPackage ./pkgs/os-specific/linux/rtirq {};
+
+}

--- a/pkgs/os-specific/linux/kernel/linux-3.18-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.18-rt.nix
@@ -1,6 +1,6 @@
-{ stdenv, hostPlatform, fetchurl, buildPackages, perl, buildLinux, ... } @ args:
+{ fetchurl, buildLinuxRT, ... } @ args:
 
-buildLinux (args // rec {
+buildLinuxRT (args // rec {
   kversion = "3.18.51";
   pversion = "rt57";
   version = "${kversion}-${pversion}";

--- a/pkgs/os-specific/linux/kernel/linux-4.1-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.1-rt.nix
@@ -1,6 +1,6 @@
-{ stdenv, hostPlatform, fetchurl, buildPackages, perl, buildLinux, ... } @ args:
+{ fetchurl, buildLinuxRT, ... } @ args:
 
-buildLinux (args // rec {
+buildLinuxRT (args // rec {
   kversion = "4.1.40";
   pversion = "rt48";
   version = "${kversion}-${pversion}";

--- a/pkgs/os-specific/linux/kernel/linux-4.11-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.11-rt.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, hostPlatform, buildPackages, perl, buildLinux, ... } @ args:
+{ fetchurl, buildLinuxRT, ... } @ args:
 
-buildLinux (args // rec {
+buildLinuxRT (args // rec {
   kversion = "4.11.12";
   pversion = "rt14";
   version = "${kversion}-${pversion}";

--- a/pkgs/os-specific/linux/kernel/linux-4.13-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.13-rt.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, hostPlatform, buildPackages, perl, buildLinux, ... } @ args:
+{ fetchurl, buildLinuxRT, ... } @ args:
 
-buildLinux (args // rec {
+buildLinuxRT (args // rec {
   kversion = "4.13.7";
   pversion = "rt1";
   version = "${kversion}-${pversion}";

--- a/pkgs/os-specific/linux/kernel/linux-4.14-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.14-rt.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, hostPlatform, buildPackages, perl, buildLinux, ... } @ args:
+{ fetchurl, buildLinuxRT, ... } @ args:
 
-buildLinux (args // rec {
+buildLinuxRT (args // rec {
   kversion = "4.14.103";
   pversion = "rt55";
   version = "${kversion}-${pversion}";

--- a/pkgs/os-specific/linux/kernel/linux-4.16-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.16-rt.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, hostPlatform, buildPackages, perl, buildLinux, ... } @ args:
+{ fetchurl, buildLinuxRT, ... } @ args:
 
-buildLinux (args // rec {
+buildLinuxRT (args // rec {
   kversion = "4.16.18";
   pversion = "rt12";
   version = "${kversion}-${pversion}";

--- a/pkgs/os-specific/linux/kernel/linux-4.18-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.18-rt.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, hostPlatform, buildPackages, perl, buildLinux, ... } @ args:
+{ fetchurl, buildLinuxRT, ... } @ args:
 
-buildLinux (args // rec {
+buildLinuxRT (args // rec {
   kversion = "4.18.16";
   pversion = "rt9";
   version = "${kversion}-${pversion}";

--- a/pkgs/os-specific/linux/kernel/linux-4.19-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.19-rt.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, hostPlatform, buildPackages, perl, buildLinux, ... } @ args:
+{ fetchurl, buildLinuxRT, ... } @ args:
 
-buildLinux (args // rec {
+buildLinuxRT (args // rec {
   kversion = "4.19.124";
   pversion = "rt53";
   version = "${kversion}-${pversion}";

--- a/pkgs/os-specific/linux/kernel/linux-4.4-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.4-rt.nix
@@ -1,6 +1,6 @@
-{ stdenv, hostPlatform, fetchurl, buildPackages, perl, buildLinux, ... } @ args:
+{ fetchurl, buildLinuxRT, ... } @ args:
 
-buildLinux (args // rec {
+buildLinuxRT (args // rec {
   kversion = "4.4.70";
   pversion = "rt83";
   version = "${kversion}-${pversion}";

--- a/pkgs/os-specific/linux/kernel/linux-4.9-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.9-rt.nix
@@ -1,6 +1,6 @@
-{ stdenv, hostPlatform, fetchurl, buildPackages, perl, buildLinux, ... } @ args:
+{ fetchurl, buildLinuxRT, ... } @ args:
 
-buildLinux (args // rec {
+buildLinuxRT (args // rec {
   kversion = "4.9.35";
   pversion = "rt25";
   version = "${kversion}-${pversion}";

--- a/pkgs/os-specific/linux/kernel/linux-5.0-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.0-rt.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, hostPlatform, buildPackages, perl, buildLinux, ... } @ args:
+{ fetchurl, buildLinuxRT, ... } @ args:
 
-buildLinux (args // rec {
+buildLinuxRT (args // rec {
   kversion = "5.0.19";
   pversion = "rt11";
   version = "${kversion}-${pversion}";

--- a/pkgs/os-specific/linux/kernel/linux-5.4-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.4-rt.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, hostPlatform, buildPackages, perl, buildLinux, ... } @ args:
+{ fetchurl, buildLinuxRT, ... } @ args:
 
-buildLinux (args // rec {
+buildLinuxRT (args // rec {
   kversion = "5.4.44";
   pversion = "rt26";
   version = "${kversion}-${pversion}";

--- a/pkgs/os-specific/linux/kernel/linux-5.6-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.6-rt.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, hostPlatform, buildPackages, perl, buildLinux, ... } @ args:
+{ fetchurl, buildLinuxRT, ... } @ args:
 
-buildLinux (args // rec {
+buildLinuxRT (args // rec {
   kversion = "5.6.17";
   pversion = "rt9";
   version = "${kversion}-${pversion}";

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,22 @@
+let
+  pkgs = import <nixpkgs> { overlays = [ (import ./overlay.nix) ]; };
+
+  jobs = rec {
+    musnixTest    = import ./tests/default.nix;
+    linux_3_18_rt = pkgs.linux_3_18_rt;
+    linux_4_1_rt  = pkgs.linux_4_1_rt;
+    linux_4_4_rt  = pkgs.linux_4_4_rt;
+    linux_4_9_rt  = pkgs.linux_4_9_rt;
+    linux_4_11_rt = pkgs.linux_4_11_rt;
+    linux_4_13_rt = pkgs.linux_4_13_rt;
+    linux_4_14_rt = pkgs.linux_4_14_rt;
+    linux_4_16_rt = pkgs.linux_4_16_rt;
+    linux_4_18_rt = pkgs.linux_4_18_rt;
+    linux_4_19_rt = pkgs.linux_4_19_rt;
+    linux_5_0_rt  = pkgs.linux_5_0_rt;
+    linux_5_4_rt  = pkgs.linux_5_4_rt;
+    linux_5_6_rt  = pkgs.linux_5_6_rt;
+    rtirq         = pkgs.rtirq;
+  };
+in
+  jobs


### PR DESCRIPTION
i took some inspiration from the old overlay-branch.

- this provides an `overlay.nix` that can be used like a regular overlay.
- using `latencytop` or `optimize` can either be enabled in the module or by overriding the packages `enableLatencytop` and `enableOptimization`.
- `rtirq` got moved into the overlay aswell.