### PR TITLE
Metadata update script

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-3.18-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.18-rt.nix
@@ -1,10 +1,11 @@
 { fetchurl, buildLinuxRT, ... } @ args:
-
+let
+  metadata = (import ./metadata.nix).kernels."3.18";
+in
 buildLinuxRT (args // rec {
-  kversion = "3.18.51";
-  pversion = "rt57";
+  inherit (metadata) kversion pversion;
   version = "${kversion}-${pversion}";
-  extraMeta.branch = "3.18";
+  extraMeta.branch = metadata.branch;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v3.x/linux-${kversion}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-4.1-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.1-rt.nix
@@ -1,10 +1,11 @@
 { fetchurl, buildLinuxRT, ... } @ args:
-
+let
+  metadata = (import ./metadata.nix).kernels."4.1";
+in
 buildLinuxRT (args // rec {
-  kversion = "4.1.40";
-  pversion = "rt48";
+  inherit (metadata) kversion pversion;
   version = "${kversion}-${pversion}";
-  extraMeta.branch = "4.1";
+  extraMeta.branch = metadata.branch;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${kversion}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-4.11-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.11-rt.nix
@@ -1,10 +1,11 @@
 { fetchurl, buildLinuxRT, ... } @ args:
-
+let
+  metadata = (import ./metadata.nix).kernels."4.11";
+in
 buildLinuxRT (args // rec {
-  kversion = "4.11.12";
-  pversion = "rt14";
+  inherit (metadata) kversion pversion;
   version = "${kversion}-${pversion}";
-  extraMeta.branch = "4.11";
+  extraMeta.branch = metadata.branch;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${kversion}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-4.13-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.13-rt.nix
@@ -1,10 +1,11 @@
 { fetchurl, buildLinuxRT, ... } @ args:
-
+let
+  metadata = (import ./metadata.nix).kernels."4.13";
+in
 buildLinuxRT (args // rec {
-  kversion = "4.13.7";
-  pversion = "rt1";
+  inherit (metadata) kversion pversion;
   version = "${kversion}-${pversion}";
-  extraMeta.branch = "4.11";
+  extraMeta.branch = metadata.branch;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${kversion}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-4.14-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.14-rt.nix
@@ -1,10 +1,11 @@
 { fetchurl, buildLinuxRT, ... } @ args:
-
+let
+  metadata = (import ./metadata.nix).kernels."4.14";
+in
 buildLinuxRT (args // rec {
-  kversion = "4.14.103";
-  pversion = "rt55";
+  inherit (metadata) kversion pversion;
   version = "${kversion}-${pversion}";
-  extraMeta.branch = "4.14";
+  extraMeta.branch = metadata.branch;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${kversion}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-4.16-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.16-rt.nix
@@ -1,10 +1,11 @@
 { fetchurl, buildLinuxRT, ... } @ args:
-
+let
+  metadata = (import ./metadata.nix).kernels."4.16";
+in
 buildLinuxRT (args // rec {
-  kversion = "4.16.18";
-  pversion = "rt12";
+  inherit (metadata) kversion pversion;
   version = "${kversion}-${pversion}";
-  extraMeta.branch = "4.14";
+  extraMeta.branch = metadata.branch;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${kversion}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-4.18-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.18-rt.nix
@@ -1,10 +1,11 @@
 { fetchurl, buildLinuxRT, ... } @ args:
-
+let
+  metadata = (import ./metadata.nix).kernels."4.18";
+in
 buildLinuxRT (args // rec {
-  kversion = "4.18.16";
-  pversion = "rt9";
+  inherit (metadata) kversion pversion;
   version = "${kversion}-${pversion}";
-  extraMeta.branch = "4.18";
+  extraMeta.branch = metadata.branch;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${kversion}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-4.19-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.19-rt.nix
@@ -1,10 +1,11 @@
 { fetchurl, buildLinuxRT, ... } @ args:
-
+let
+  metadata = (import ./metadata.nix).kernels."4.19";
+in
 buildLinuxRT (args // rec {
-  kversion = "4.19.124";
-  pversion = "rt53";
+  inherit (metadata) kversion pversion;
   version = "${kversion}-${pversion}";
-  extraMeta.branch = "4.19";
+  extraMeta.branch = metadata.branch;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${kversion}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-4.4-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.4-rt.nix
@@ -1,10 +1,11 @@
 { fetchurl, buildLinuxRT, ... } @ args:
-
+let
+  metadata = (import ./metadata.nix).kernels."4.4";
+in
 buildLinuxRT (args // rec {
-  kversion = "4.4.70";
-  pversion = "rt83";
+  inherit (metadata) kversion pversion;
   version = "${kversion}-${pversion}";
-  extraMeta.branch = "4.4";
+  extraMeta.branch = metadata.branch;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${kversion}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-4.9-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.9-rt.nix
@@ -1,10 +1,11 @@
 { fetchurl, buildLinuxRT, ... } @ args:
-
+let
+  metadata = (import ./metadata.nix).kernels."4.9";
+in
 buildLinuxRT (args // rec {
-  kversion = "4.9.35";
-  pversion = "rt25";
+  inherit (metadata) kversion pversion;
   version = "${kversion}-${pversion}";
-  extraMeta.branch = "4.9";
+  extraMeta.branch = metadata.branch;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${kversion}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-5.0-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.0-rt.nix
@@ -1,10 +1,11 @@
 { fetchurl, buildLinuxRT, ... } @ args:
-
+let
+  metadata = (import ./metadata.nix).kernels."5.0";
+in
 buildLinuxRT (args // rec {
-  kversion = "5.0.19";
-  pversion = "rt11";
+  inherit (metadata) kversion pversion;
   version = "${kversion}-${pversion}";
-  extraMeta.branch = "5.0";
+  extraMeta.branch = metadata.branch;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${kversion}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-5.4-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.4-rt.nix
@@ -1,13 +1,14 @@
 { fetchurl, buildLinuxRT, ... } @ args:
-
+let
+  metadata = (import ./metadata.nix).kernels."5.4";
+in
 buildLinuxRT (args // rec {
-  kversion = "5.4.44";
-  pversion = "rt26";
+  inherit (metadata) kversion pversion;
   version = "${kversion}-${pversion}";
-  extraMeta.branch = "5.4";
+  extraMeta.branch = metadata.branch;
 
   src = fetchurl {
+    inherit (metadata) sha256;
     url = "mirror://kernel/linux/kernel/v5.x/linux-${kversion}.tar.xz";
-    sha256 = "0fc4nsv1zwlknvfv1bzkjlq2vlx28wfl09hg2p7r8cn7a77bphlp";
   };
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-5.6-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.6-rt.nix
@@ -1,10 +1,11 @@
 { fetchurl, buildLinuxRT, ... } @ args:
-
+let
+  metadata = (import ./metadata.nix).kernels."5.6";
+in
 buildLinuxRT (args // rec {
-  kversion = "5.6.17";
-  pversion = "rt9";
+  inherit (metadata) kversion pversion;
   version = "${kversion}-${pversion}";
-  extraMeta.branch = "5.6";
+  extraMeta.branch = metadata.branch;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${kversion}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/metadata.nix
+++ b/pkgs/os-specific/linux/kernel/metadata.nix
@@ -1,0 +1,146 @@
+{
+  kernels."3.18" = {
+    branch = "3.18";
+    kversion = "3.18.140";
+    pversion = "rt117";
+    sha256 = "1q72vidhkcnp82aaxi3cn4h0bv9i34n44r6k6ls8awqkql0qkhqq";
+  };
+  patches."3.18" = {
+    branch = "3.18";
+    kversion = "3.18.140";
+    pversion = "rt117";
+    sha256 = "09a3729kadjnnb7cc3vyps6xlm37m3npaz0vc4y7fp5ih7z907aj";
+  };
+  kernels."4.1" = {
+    branch = "4.1";
+    kversion = "4.1.46";
+    pversion = "rt52";
+    sha256 = "0h0mcvc2554qb1m2nfqs0r179gwvfinyhpf11k8cf4801z168p9x";
+  };
+  patches."4.1" = {
+    branch = "4.1";
+    kversion = "4.1.46";
+    pversion = "rt52";
+    sha256 = "0jii12w9a6hh3g2pi2c5x4xwrdcrppl09b4d91m36nsfixsqwchl";
+  };
+  kernels."4.4" = {
+    branch = "4.4";
+    kversion = "4.4.225";
+    pversion = "rt198";
+    sha256 = "0pn66hf9yrjg15skq1inscr5m0slvgsd2qm8rg5id70llrb4jis9";
+  };
+  patches."4.4" = {
+    branch = "4.4";
+    kversion = "4.4.225";
+    pversion = "rt198";
+    sha256 = "0dp11m81c5ycm9vvi55wry9wyhwryzaw7imgp4x8qz9yamg38fpw";
+  };
+  kernels."4.9" = {
+    branch = "4.9";
+    kversion = "4.9.228";
+    pversion = "rt147";
+    sha256 = "0d7w2zzs79ywxzfrh4bmk5lw318qbkcb8mcsyyh3cc25qqlz9gwg";
+  };
+  patches."4.9" = {
+    branch = "4.9";
+    kversion = "4.9.228";
+    pversion = "rt147";
+    sha256 = "0rym9d3awbdpqxhnqjl69zplywsvhzlzwyadivs7a4fwhfzk3k4n";
+  };
+  kernels."4.11" = {
+    branch = "4.11";
+    kversion = "4.11.12";
+    pversion = "rt16";
+    sha256 = "14k10g9w8dp3lmw1qjns395a2fcaq2iw1jijss5npxllh3hx8drf";
+  };
+  patches."4.11" = {
+    branch = "4.11";
+    kversion = "4.11.12";
+    pversion = "rt16";
+    sha256 = "1g9nbvp7nfqkbyjq7fvr35f4srhapdr5lynazj19bah4vvvjlwkh";
+  };
+  kernels."4.14" = {
+    branch = "4.14";
+    kversion = "4.14.186";
+    pversion = "rt86";
+    sha256 = "0q52fmkiqa9hpdkf0wlpcqnc6wqssqz6cgfk1ix1anq0h5hl4ns4";
+  };
+  patches."4.14" = {
+    branch = "4.14";
+    kversion = "4.14.186";
+    pversion = "rt86";
+    sha256 = "1aqg2sz9q4vgliwpcms956bkg2cjsqrkq1brnb12fpqy9kcf0ap1";
+  };
+  kernels."4.16" = {
+    branch = "4.16";
+    kversion = "4.16.18";
+    pversion = "rt12";
+    sha256 = "089hx2hdd5r558mv8n0c7jciv2nj9v77df0lsplsbxx47dqns0j1";
+  };
+  patches."4.16" = {
+    branch = "4.16";
+    kversion = "4.16.18";
+    pversion = "rt12";
+    sha256 = "1rh36wfgg5x15nrx7zd0cfpkjrvlagsvpdf806la4fsyr7gcqwa7";
+  };
+  kernels."4.18" = {
+    branch = "4.18";
+    kversion = "4.18.16";
+    pversion = "rt9";
+    sha256 = "1rjjkhl8lz4y4sn7icy8mp6p1x7rvapybp51p92sanbjy3i19fmy";
+  };
+  patches."4.18" = {
+    branch = "4.18";
+    kversion = "4.18.16";
+    pversion = "rt9";
+    sha256 = "04zzm1mlm9km1776w9bgblyr6c36wc10wmyvkf4pimwdd7ch50mb";
+  };
+  kernels."4.19" = {
+    branch = "4.19";
+    kversion = "4.19.127";
+    pversion = "rt55";
+    sha256 = "0vsq5vjyh6n8acjnldfs0zny63l12fn2pssb8zbwidc8qmmqibw2";
+  };
+  patches."4.19" = {
+    branch = "4.19";
+    kversion = "4.19.127";
+    pversion = "rt55";
+    sha256 = "0alxp9af1arssy02ydcxfpfkpvxa7pmxkfwib29j149mg04s00ky";
+  };
+  kernels."5.0" = {
+    branch = "5.0";
+    kversion = "5.0.21";
+    pversion = "rt16";
+    sha256 = "1my2m9hvnvdrvzcg0fgqgaga59y2cd5zlpv7xrfj2nn98sjhglwq";
+  };
+  patches."5.0" = {
+    branch = "5.0";
+    kversion = "5.0.21";
+    pversion = "rt16";
+    sha256 = "0qcp6ilkdhibdycmblpd08wyivg2h2vsx8z9v9924lvsdmg6njgq";
+  };
+  kernels."5.4" = {
+    branch = "5.4";
+    kversion = "5.4.47";
+    pversion = "rt28";
+    sha256 = "0v4d86yci4lq82nb1fgf0g3j0348v6q6m77czpm4b3cs7lwrs2wp";
+  };
+  patches."5.4" = {
+    branch = "5.4";
+    kversion = "5.4.47";
+    pversion = "rt28";
+    sha256 = "0qn5h9h696pw7vrqfi4pj7r7f0czi3w88f3i14zs5s0nx1wi7p6s";
+  };
+  kernels."5.6" = {
+    branch = "5.6";
+    kversion = "5.6.17";
+    pversion = "rt10";
+    sha256 = "17kzalz8z6svv6nwa3dbmf7nyvpb2wwwyabj19vdwf6v05a28fn3";
+  };
+  patches."5.6" = {
+    branch = "5.6";
+    kversion = "5.6.17";
+    pversion = "rt10";
+    sha256 = "1drzqf19gna16c0s65b8i1xf5khq41v686y6gh0v8cpklr0579hm";
+  };
+}

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -15,96 +15,22 @@ let
       };
     };
 
-in rec {
+  metadata = (import ./metadata.nix).patches;
 
-  realtimePatch_3_18 = realtimePatch
-    { branch = "3.18";
-      kversion = "3.18.51";
-      pversion = "rt57";
-      sha256 = "057f39vn520lf1my9fdfjfbmfm4jp6qwpsq068ci96q983jn6mvg";
-    };
+in {
 
-  realtimePatch_4_1 = realtimePatch
-    { branch = "4.1";
-      kversion = "4.1.40";
-      pversion = "rt48";
-      sha256 = "0b5sdzlzi6bjmbvmhxb72w73pafr30yawzjd4is7vzcd8b71y227";
-    };
+  realtimePatch_3_18 = realtimePatch metadata."3.18";
+  realtimePatch_4_1  = realtimePatch metadata."4.1";
+  realtimePatch_4_4  = realtimePatch metadata."4.4";
+  realtimePatch_4_9  = realtimePatch metadata."4.9";
+  realtimePatch_4_11 = realtimePatch metadata."4.11";
+  realtimePatch_4_13 = realtimePatch metadata."4.13";
+  realtimePatch_4_14 = realtimePatch metadata."4.14";
+  realtimePatch_4_16 = realtimePatch metadata."4.16";
+  realtimePatch_4_18 = realtimePatch metadata."4.18";
+  realtimePatch_4_19 = realtimePatch metadata."4.19";
+  realtimePatch_5_0  = realtimePatch metadata."5.0";
+  realtimePatch_5_4  = realtimePatch metadata."5.4";
+  realtimePatch_5_6  = realtimePatch metadata."5.6";
 
-  realtimePatch_4_4 = realtimePatch
-    { branch = "4.4";
-      kversion = "4.4.70";
-      pversion = "rt83";
-      sha256 = "1kannihx8hcykdachi14myapsdgpwxl2gkwfy0ylb9khjp6zw9yw";
-    };
-
-  realtimePatch_4_9 = realtimePatch
-    { branch = "4.9";
-      kversion = "4.9.35";
-      pversion = "rt25";
-      sha256 = "0vm7dpdaspwyccx2lh6sycfcaaiw1439fpnhypm5cya0ymsnz0fj";
-    };
-
-  realtimePatch_4_11 = realtimePatch
-    { branch = "4.11";
-      kversion = "4.11.12";
-      pversion = "rt14";
-      sha256 = "0zh0xfw34abwaadlskdgbmm9cgz88kw7ss5scq4x821qx9n11a0b";
-    };
-
-  realtimePatch_4_13 = realtimePatch
-    { branch = "4.13";
-      kversion = "4.13.7";
-      pversion = "rt1";
-      sha256 = "0jmwwy6yf19apqh6m8cc3k16czgjb1vlhg02r78zpxx77w793x2z";
-    };
-
-  realtimePatch_4_14 = realtimePatch
-    { branch = "4.14";
-      kversion = "4.14.103";
-      pversion = "rt55";
-      sha256 = "0ccn0f2yvrjsx8rwlg8x6xgqa1mch1r5372k6vfwq394jxi82d6g";
-    };
-
-  realtimePatch_4_16 = realtimePatch
-    { branch = "4.16";
-      kversion = "4.16.18";
-      pversion = "rt12";
-      sha256 = "1rh36wfgg5x15nrx7zd0cfpkjrvlagsvpdf806la4fsyr7gcqwa7";
-    };
-
-  realtimePatch_4_18 = realtimePatch
-    { branch = "4.18";
-      kversion = "4.18.16";
-      pversion = "rt9";
-      sha256 = "04zzm1mlm9km1776w9bgblyr6c36wc10wmyvkf4pimwdd7ch50mb";
-    };
-
-  realtimePatch_4_19 = realtimePatch
-    { branch = "4.19";
-      kversion = "4.19.124";
-      pversion = "rt53";
-      sha256 = "06l65z626y9gh437n3b8cxafgbqlclagwpwixzr7zdn8lrby0yiw";
-    };
-
-  realtimePatch_5_0 = realtimePatch
-    { branch = "5.0";
-      kversion = "5.0.19";
-      pversion = "rt11";
-      sha256 = "005krk67w8742nqv63b8mnjkssw6db3k19x1jdfr26rgdcq9azbi";
-    };
-
-  realtimePatch_5_4 = realtimePatch
-    { branch = "5.4";
-      kversion = "5.4.44";
-      pversion = "rt26";
-      sha256 = "16piyv1a167gl8hvnn3hyxw5bz97xhz8i97f4zpb7l28lj3iixvx";
-    };
-
-  realtimePatch_5_6 = realtimePatch
-    { branch = "5.6";
-      kversion = "5.6.17";
-      pversion = "rt9";
-      sha256 = "0k0inq5pjk50yii9dsvhpip76naal5f73i736fvd5qz1l5gayy0b";
-    };
 }

--- a/pkgs/os-specific/linux/kernel/update.sh
+++ b/pkgs/os-specific/linux/kernel/update.sh
@@ -1,6 +1,9 @@
 #! /usr/bin/env nix-shell
 #! nix-shell -i bash -p nixfmt
 
+set -o errexit
+set -o pipefail
+
 BRANCHES=(
   "3.18"
   "4.1" "4.4" "4.9" "4.11" "4.14" "4.16" "4.18" "4.19"

--- a/pkgs/os-specific/linux/kernel/update.sh
+++ b/pkgs/os-specific/linux/kernel/update.sh
@@ -1,0 +1,53 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p nixfmt
+
+BRANCHES=(
+  "3.18"
+  "4.1" "4.4" "4.9" "4.11" "4.14" "4.16" "4.18" "4.19"
+  "5.0" "5.4" "5.6"
+)
+
+OUTPUT=metadata.nix
+OUTPUT_TMP=$OUTPUT.tmp
+
+URL_BASE_KERNEL="mirror://kernel/linux/kernel"
+URL_BASE_RT="https://mirrors.edge.kernel.org/pub/linux/kernel/projects/rt"
+
+function update_branch() {
+  kernel_branch=$1
+  >&2 echo "- updating kernel-branch: $kernel_branch"
+  patch_version_string=$(
+    curl -q $URL_BASE_RT/$kernel_branch/sha256sums.asc 2>/dev/null |
+    sed -rn 's/^.*patch-(.*).patch.xz.*$/\1/p' |
+    sort -V | tail -n 1
+  )
+  kernel_version=$(echo $patch_version_string | cut -d'-' -f1)
+  patch_version=$(echo $patch_version_string | cut -d'-' -f2)
+  patch_url="$URL_BASE_RT/$kernel_branch/older/patch-$patch_version_string.patch.xz"
+  patch_hash=$(nix-prefetch-url $patch_url)
+  kernel_version_major=$(echo $kernel_version | cut -d'.' -f1)
+  kernel_url="$URL_BASE_KERNEL/v$kernel_version_major.x/linux-$kernel_version.tar.xz"
+  kernel_hash=$(nix-prefetch-url $kernel_url)
+  >&2 echo "+ kernel-version: $kernel_version"
+  >&2 echo "+ kernel-url: $kernel_url"
+  >&2 echo "+ kernel-hash: $kernel_hash"
+  >&2 echo "+ patch-version: $patch_version"
+  >&2 echo "+ patch-url: $patch_url"
+  >&2 echo "+ patch-hash: $patch_hash"
+  printf 'kernels."%s" = { branch = "%s"; kversion = "%s"; pversion = "%s"; sha256 = "%s"; };\n' \
+    $kernel_branch $kernel_branch $kernel_version $patch_version $kernel_hash
+  printf 'patches."%s" = { branch = "%s"; kversion = "%s"; pversion = "%s"; sha256 = "%s"; };\n' \
+    $kernel_branch $kernel_branch $kernel_version $patch_version $patch_hash
+}
+
+function main() {
+  echo "{" > $OUTPUT_TMP
+  for b in "${BRANCHES[@]}"; do
+    update_branch $b >> $OUTPUT_TMP
+  done
+  echo "}" >> $OUTPUT_TMP
+  nixfmt $OUTPUT_TMP
+  mv $OUTPUT_TMP $OUTPUT
+}
+
+main


### PR DESCRIPTION
depends on #116 

**motivation:**
i noticed that some kernel-packages and patches weren't up-to-date.

**description:**
i adopted the `metadata.nix` approach.
- `metadata.nix` contains versions and hashes for all packages.
- all packages use the information from `metadata.nix`
- `metadata.nix` can be automatically updated using `update.sh`
