### PR TITLE
Update rtirq

### DIFF
--- a/pkgs/os-specific/linux/rtirq/default.nix
+++ b/pkgs/os-specific/linux/rtirq/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://www.rncbc.org/archive/${name}-${version}.tar.gz";
-    sha256 = "0yb1d640z93kspwxihqsra26fyhazp24grcdy3fdkbnffprl5nx1";
+    sha256 = "1z55pljw7mz3smyljxlg7144rn305sran6x3d3y26fb9hsa6gxfq";
   };
 
   phases = [ "unpackPhase" "patchPhase" "installPhase" ];

--- a/pkgs/os-specific/linux/rtirq/default.nix
+++ b/pkgs/os-specific/linux/rtirq/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "rtirq";
-  version = "20191121";
+  version = "20210113";
 
   src = fetchurl {
     url = "http://www.rncbc.org/archive/${name}-${version}.tar.gz";


### PR DESCRIPTION
Version `20191121` is no longer available, this PR updates it to `20210113`.