### PR TITLE
Flake: Initial Musnix Flake support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,32 @@ To update musnix, run:
 sudo -i nix-channel --update musnix
 ```
 
+### Using musnix as a flake
+As an alternative to nix-channels or cloning the project you can instead use it as a flake in a pure system.
+
+```nix
+{
+  inputs = {
+    nixpkgs = { url = "github:NixOS/nixpkgs/nixos-unstable"; };
+    musnix = { url = "github:musnix/musnix"; };
+  };
+  outputs = inputs: rec {
+    nixosConfigurations = {
+      example-config = inputs.nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          ## Other modules will also be here
+          inputs.musnix.nixosModules.musnix
+          ./configuration.nix ## Configuration file from regular /etc/nixos config
+        ];
+        specialArgs = { inherit inputs; }; ## Inherit inputs to configuration.nix so you can call inputs.inputname
+       };
+      };
+  }
+```
+
+after applying this config all musnix.* configuration options will be available the same way that a nix-channel or a clone would be available
+
 ## Base Options
 
 `musnix.enable`

--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ As an alternative to nix-channels or cloning the project you can instead use it 
       };
   }
 ```
+The above code snipped properly adds the repo's git repo to your config and `inputs.musnix.nixosModules.musnix` automatically adds a musnix modules.
 
-after applying this config all musnix.* configuration options will be available the same way that a nix-channel or a clone would be available
+The flake.nix automatically gets "imported" (not an actual import but close enough in function for non-flake users) and it adds musnix packages and modules via adding `inputs.musnix.nixosModules.musnix` to the `modules`section.
 
 ## Base Options
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ As an alternative to nix-channels or cloning the project you can instead use it 
       };
   }
 ```
-The above code snipped properly adds the repo's git repo to your config and `inputs.musnix.nixosModules.musnix` automatically adds a musnix modules.
+The above code snippet is a full user-side flake.nix, and it properly adds the repo's git repo to your config and `inputs.musnix.nixosModules.musnix` automatically adds a musnix modules.
 
-The flake.nix automatically gets "imported" (not an actual import but close enough in function for non-flake users) and it adds musnix packages and modules via adding `inputs.musnix.nixosModules.musnix` to the `modules`section.
+The flake.nix, from the repo, automatically gets "imported" (not an actual import but close enough in function for non-flake users) and it adds musnix packages and modules via adding `inputs.musnix.nixosModules.musnix` to the `modules`section.
 
 ## Base Options
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1623743177,
+        "narHash": "sha256-57OM8Ya/yGHAHBq/h0I8Ah/HJFmk0VNpEASYxr+BgK8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4b7c8d538e1aed2bc30b6e7eb1cbd96063ad4132",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,7 @@
         nixosModules.rtirq = forAllSystems (system: import ./default.nix {
             inherit system;
         });
+        nixosModules.musnix = import ./default.nix;
         nixosModule = self.nixosModules.musnix;
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,16 @@
+{
+    description = "Real-time audio in NixOS";
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    outputs = { self, nixpkgs }: let
+        systems = [
+            "x86_64-linux"
+            "aarch64-linux"
+        ];
+        forAllSystems = import ./default.nix { pkgs = final; };
+    in {
+        nixosModules.rtirq = forAllSystems (system: import ./default.nix {
+            inherit system;
+        });
+        nixosModule = self.nixosModules.musnix;
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,13 +1,7 @@
 {
     description = "Real-time audio in NixOS";
     inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    outputs = { self, nixpkgs }: let
-        systems = [
-            "x86_64-linux"
-            "aarch64-linux"
-        ];
-        forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
-    in {
+    outputs = { self, nixpkgs }: {
         nixosModules.musnix = import ./default.nix;
         nixosModule = self.nixosModules.musnix;
     };

--- a/flake.nix
+++ b/flake.nix
@@ -8,9 +8,6 @@
         ];
         forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
     in {
-        nixosModules.rtirq = forAllSystems (system: import ./default.nix {
-            inherit system;
-        });
         nixosModules.musnix = import ./default.nix;
         nixosModule = self.nixosModules.musnix;
     };

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
             "x86_64-linux"
             "aarch64-linux"
         ];
-        forAllSystems = import ./default.nix { pkgs = final; };
+        forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
     in {
         nixosModules.rtirq = forAllSystems (system: import ./default.nix {
             inherit system;


### PR DESCRIPTION
NixOS flake support for musnix, will function the same way as regular nix-channel or clone.