### PR TITLE
utillinux → util-linux

### DIFF
--- a/pkgs/os-specific/linux/rtirq/default.nix
+++ b/pkgs/os-specific/linux/rtirq/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, utillinux, lib }:
+{ stdenv, fetchurl, util-linux, lib }:
 
 stdenv.mkDerivation rec {
   name = "rtirq";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   patchPhase = ''
     patchShebangs rtirq.sh
     substituteInPlace rtirq.sh \
-      --replace "/sbin /usr/sbin /bin /usr/bin /usr/local/bin" "${utillinux}/bin"
+      --replace "/sbin /usr/sbin /bin /usr/bin /usr/local/bin" "${util-linux}/bin"
   '';
 
   installPhase = ''


### PR DESCRIPTION
`rtirq` no longer builds on nixpkgs master because it uses a now-obsolete alias of `util-linux` (see https://github.com/NixOS/nixpkgs/pull/104776, https://github.com/NixOS/nixpkgs/commit/d06207386df9a53fe01f8a30130dfc9a839fc8fc, https://github.com/NixOS/nixpkgs/commit/ba3319568df2c6675dbe36478fb3edf16e114ac3). This tiny PR removes the use of the alias.