### PR TITLE
Remove references to max_user_freq

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,6 @@ The flake.nix, from the repo, automatically gets "imported" (not an actual impor
     KERNEL=="hpet", GROUP="audio"
     ```
 
-  * Set the `max_user_freq` of `/sys/class/rtc/rtc0` to 2048.
-
-  * Set the `max-user-freq` of `/proc/sys/dev/hpet` to 2048.
-
   * Set the following PAM limits:
     ```
     @audio  -       memlock unlimited


### PR DESCRIPTION
While trying out the module installation I tried to test `musnix.enable = true` was properly working by trying to read the value `2048` from `/proc/sys/dev/hpet/max_user_freq`. As the value was not updated, I thought I was doing something wrong setting up my configuration files. Then I found out [this commit](https://github.com/musnix/musnix/commit/e6850703264e2558f19343c01d901808c7be17f6) where those values are taken away from the configuration.

Even if it's not a complete proposal of documentation update, I hope taking this references out will prevent others from getting confused like I was :)