### PR TITLE
Switch linuxPackages_latest_rt to 5.9

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -156,7 +156,7 @@ with lib;
   linuxPackages_rt = self.linuxPackages_5_4_rt;
   linux_rt = self.linuxPackages_rt.kernel;
 
-  linuxPackages_latest_rt = self.linuxPackages_5_6_rt;
+  linuxPackages_latest_rt = self.linuxPackages_5_9_rt;
   linux_latest_rt = self.linuxPackages_latest_rt.kernel;
 
   realtimePatches = callPackage ./pkgs/os-specific/linux/kernel/patches.nix {};


### PR DESCRIPTION
5.6 is no longer buildable on unstable and 6.0 is not yet buildable.

Closes #140