### PR TITLE
kernel: add option to enable timerlat tracing

### DIFF
--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -42,6 +42,16 @@ in {
         patch to the kernel.
       '';
     };
+    kernel.timerlat = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        NOTE: Enabling this option will rebuild your kernel.
+
+        If enabled, this option will enable the 
+        CONFIG_TIMERLAT_TRACER option in the kernel.
+      '';
+    };
     kernel.packages = mkOption {
       default = pkgs.linuxPackages_5_4_rt;
       description = ''
@@ -66,7 +76,7 @@ in {
     };
   };
 
-  config = mkIf (cfg.kernel.latencytop || cfg.kernel.optimize || cfg.kernel.realtime) {
+  config = mkIf (cfg.kernel.latencytop || cfg.kernel.optimize || cfg.kernel.realtime || cfg.kernel.timerlat) {
 
     boot.kernelPackages =
       if cfg.kernel.realtime


### PR DESCRIPTION
This is a first stab at adding an option to enable timerlat tracing which is useful for debugging latency spikes in otherwise well tuned systems. I'm not sure if it works - I never before worked with options in overlays. Rebuilding the kernel takes ca. 3 hours on my system, so I'm hesitant to test right now. 

<code>nixos-rebuild dry-build</code> at least doesn't complain.. 

Is there a way to just build the kernel config and not the resulting kernel? Then I could check wether the option is applied correctly to the kernel config..
