### PR TITLE
Fix overlay

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -20,7 +20,7 @@ let
     whenBetween = verLow: verHigh: mkIf (versionAtLeast version verLow && versionOlder version verHigh);
   };
 
-  cfg = super.config.musnix or {
+  cfg = (import <nixpkgs/nixos> { }).config.musnix or {
     kernel.latencytop = false;
     kernel.optimize = false;
   };

--- a/overlay.nix
+++ b/overlay.nix
@@ -34,7 +34,7 @@ let
     with (whenHelpers version);
     lib.optionalAttrs enableLatencytop {
       LATENCYTOP = yes;
-      SCHEDSTATS = yes;
+      SCHEDSTATS = lib.mkForce yes;
     } //
     lib.optionalAttrs enableOptimization {
       PREEMPT = yes;

--- a/overlay.nix
+++ b/overlay.nix
@@ -20,7 +20,7 @@ let
     whenBetween = verLow: verHigh: mkIf (versionAtLeast version verLow && versionOlder version verHigh);
   };
 
-  cfg = (import <nixpkgs/nixos> { }).config.musnix or {
+  cfg = super.config.musnix or (import <nixpkgs/nixos> { }).config.musnix or {
     kernel.latencytop = false;
     kernel.optimize = false;
   };


### PR DESCRIPTION
OK,

during addition of the <code>timerlat</code> option I was confused since no matter how I set the option there was no kernel rebuild triggered. Then I tried changing the other options defined in a similar way like <code>latencytop</code> or <code>optimize</code> and they also didn't trigger any rebuilds (or at least it didn't appear so from <code>nixos-rebuild dry-build</code>. 

Anyways, it seems to actually get the system config in an overlay one needs to do a little dance. This PR performs this dance and fixes a small conflict with the <code>common-config.nix</code> shipped with nixpkgs if one enables latencytop.