### PR TITLE
remove kernel.{latencytop,optimize} features

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,12 +147,6 @@ The flake.nix, from the repo, automatically gets "imported" (not an actual impor
 
 **NOTE**: The following kernel options can be used without setting `musnix.enable = true;`
 
-`musnix.kernel.optimize`
-* **NOTE:** Enabling this option will rebuild your kernel.
-* **Description:** If enabled, this option will configure the kernel to be preemptible, to use the deadline I/O scheduler, and to use the High Precision Event Timer (HPET).
-* **Type:** `boolean`
-* **Default value:** `false`
-
 `musnix.kernel.realtime`
 * **NOTE:** Enabling this option will rebuild your kernel.
 * **Description:** If enabled, this option will apply the [`CONFIG_PREEMPT_RT`](https://rt.wiki.kernel.org/index.php/Main_Page) patch to the kernel.
@@ -171,13 +165,6 @@ The flake.nix, from the repo, automatically gets "imported" (not an actual impor
   * `pkgs.linuxPackages_rt` (currently `pkgs.linuxPackages_5_15_rt`)
   * `pkgs.linuxPackages_latest_rt` (currently `pkgs.linuxPackages_6_0_rt`)
   
-`musnix.kernel.latencytop`
-* **NOTE:** Enabling this option will rebuild your kernel.
-* **NOTE:** This option is only intended to be used for diagnostic purposes, and may cause other issues.
-* **Description:** If enabled, this option will configure the kernel to use a latency tracking infrastructure that is used by the "latencytop" userspace tool.
-* **Type:** `boolean`
-* **Default value:** `false`
-
 ## rtirq Options
 
 **NOTES**:

--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -8,30 +8,6 @@ let
 
 in {
   options.musnix = {
-    kernel.latencytop = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        NOTE: Enabling this option will rebuild your kernel.
-
-        NOTE: This option is only intended to be used for diagnostic purposes,
-        and may cause other issues.
-
-        If enabled, this option will configure the kernel to use a
-        latency tracking infrastructure that is used by the
-        "latencytop" userspace tool.
-      '';
-    };
-    kernel.optimize = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        NOTE: Enabling this option will rebuild your kernel.
-
-        If enabled, this option will configure the kernel to be
-        preemptible and use the deadline I/O scheduler.
-      '';
-    };
     kernel.realtime = mkOption {
       type = types.bool;
       default = false;
@@ -58,12 +34,10 @@ in {
     };
   };
 
-  config = mkIf (cfg.kernel.latencytop || cfg.kernel.optimize || cfg.kernel.realtime) {
-
+  config = mkIf cfg.kernel.realtime {
     boot.kernelPackages =
       if cfg.kernel.realtime
         then cfg.kernel.packages
         else pkgs.linuxPackages_opt;
-
   };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -12,7 +12,6 @@ import <nixpkgs/nixos/tests/make-test-python.nix> {
     { imports = [ ../default.nix ];
 
       musnix.enable = true;
-      musnix.kernel.optimize = true;
       musnix.kernel.realtime = true;
       musnix.rtirq.enable = true;
       musnix.rtirq.highList = "timer";


### PR DESCRIPTION
As discussed in #149, it looks like the `kernel.latencytop` and `kernel.optimize` settings didn't survive the transition to the overlay.  IIRC, the features of the latter have been subsumed into the mainline kernel defaults.

It's not yet clear to me how to make them work as they once did, but I think it's best if we remove them for now, as they are basically broken.