### PR TITLE
Don't create audio group

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -101,7 +101,5 @@ in {
         KERNEL=="hpet", GROUP="audio"
       '';
     };
-
-    users.extraGroups = { audio = {}; };
   };
 }


### PR DESCRIPTION
This group is already [pre-configured](https://github.com/NixOS/nixpkgs/blob/33c9fd85e52f925e05f4a6bd69811f97e5ccdc15/nixos/modules/config/users-groups.nix#L572) in NixOS installations