### PR TITLE
Fix ffado.enable to point to proper ffado package

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -94,7 +94,7 @@ in {
     services.udev = {
       packages =
         if cfg.ffado.enable
-          then [ pkgs.ffadoFull ]
+          then [ pkgs.ffado ]
           else [];
       extraRules = ''
         KERNEL=="rtc0", GROUP="audio"


### PR DESCRIPTION
From 18.09 onwards, the package for ffado is `ffado` instead of `ffadoFull`.