### PR TITLE
Replaced from ffadoFull to ffado on the line62.

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -62,7 +62,7 @@ in {
 
     environment.systemPackages =
       if cfg.ffado.enable
-        then [ pkgs.ffadoFull ]
+        then [ pkgs.ffado ]
         else [];
 
     environment.variables = let


### PR DESCRIPTION
It seems that the current master branch still had the "ffadoFull" notation.
A small change finally fixed the error on `nixos-rebuild switch`.

pkgURL: https://search.nixos.org/packages?channel=23.05&show=ffado&from=0&size=50&sort=relevance&type=packages&query=ffado