### PR TITLE
Fix minor typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ To see a description of one of the listed options (in this case `enable`):
 `musnix.das_watchdog.enable`
 * **Description:** If enabled, start the [das_watchdog](https://github.com/kmatheussen/das_watchdog) service.  This service will ensure that a realtime process won't hang the machine.
 * **Type:** `boolean`
-* **Default value:** `true` if `musnix.kernel.realtime.enable = true`, otherwise `false`
+* **Default value:** `true` if `musnix.kernel.realtime = true`, otherwise `false`
 
 ## Communication
 


### PR DESCRIPTION
The option is `musnix.kernel.realtime`, not `musnix.kernel.realtime.enable`.