### PR TITLE
Fix missing s in threadirqs kernel parameter

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -53,7 +53,7 @@ in {
                  "snd-rawmidi"
                ]
           else [];
-      kernelParams = [ "threadirq" ];
+      kernelParams = [ "threadirqs" ];
       postBootCommands = optionalString (cfg.soundcardPciId != "") ''
         ${pkgs.pciutils}/bin/setpci -v -d *:* latency_timer=b0
         ${pkgs.pciutils}/bin/setpci -v -s ${cfg.soundcardPciId} latency_timer=ff


### PR DESCRIPTION
It seems like the `threadirqs` kernel parameter[1] is missing an `s`

[1]: https://docs.kernel.org/admin-guide/kernel-parameters.html