### PR TITLE
Allow overrides of environment variables without mkForce

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -74,12 +74,12 @@ in {
         ])
         + ":$HOME/.${format}";
     in {
-      DSSI_PATH   = makePluginPath "dssi";
-      LADSPA_PATH = makePluginPath "ladspa";
-      LV2_PATH    = makePluginPath "lv2";
-      LXVST_PATH  = makePluginPath "lxvst";
-      VST_PATH    = makePluginPath "vst";
-      VST3_PATH   = makePluginPath "vst3";
+      DSSI_PATH   = lib.mkDefault (makePluginPath "dssi");
+      LADSPA_PATH = lib.mkDefault (makePluginPath "ladspa");
+      LV2_PATH    = lib.mkDefault (makePluginPath "lv2");
+      LXVST_PATH  = lib.mkDefault (makePluginPath "lxvst");
+      VST_PATH    = lib.mkDefault (makePluginPath "vst");
+      VST3_PATH   = lib.mkDefault (makePluginPath "vst3");
     };
 
     powerManagement.cpuFreqGovernor = "performance";


### PR DESCRIPTION
Currently to override any plugin envvars set by musnix, you must use lib.mkForce.  This makes it possible to disuse lib.mkForce, and is backwards compatible.

If someone can think of a way to test this, I'd be happy to add a test too.