### PR TITLE
Add musnix.rtcsq.enable option and related test

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -6,9 +6,14 @@ jobs:
   evaluate:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v18
+    - uses: jlumbroso/free-disk-space@main
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v26
       with:
-        nix_path: nixpkgs=channel:nixos-unstable
-    - run: nix-build --dry-run release.nix
-    - run: nix flake check
+        nix_path: nixpkgs=channel:nixos-unstable      
+    - run: nix build --dry-run --file release.nix
+    - run: nix flake check -L
+
+# potential improvements:
+#   - populate a Cachix cache with realtime kernels (speed/disk space)
+#   - figure out the purpose of "nix build --dry-run --file release.nix"

--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ As an alternative to the above approaches, you can also add musnix as a flake:
 * **Type:** `boolean`
 * **Default value:** `false`
 
+`musnix.rtcqs.enable`
+* **Description:** If enabled, install the [rtcqs command-line utulity](https://wiki.linuxaudio.org/wiki/system_configuration#rtcqs), which analyzes the system and makes suggestions about what to change to make it more audio-friendly.
+* **Type:** `boolean`
+* **Default value:** `false`
+
 `musnix.soundcardPciId`
 * **Description:** The PCI ID of the primary soundcard. Used to set the PCI latency timer.
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1690272529,
-        "narHash": "sha256-MakzcKXEdv/I4qJUtq/k/eG+rVmyOZLnYNC2w1mB59Y=",
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ef99fa5c5ed624460217c31ac4271cfb5cb2502c",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,18 @@
 {
   description = "Real-time audio in NixOS";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-  outputs = { self, nixpkgs }: {
-    nixosModules.musnix = import ./default.nix;
-    nixosModules.default = self.nixosModules.musnix;
+  outputs = { self, nixpkgs }: let
+      forAllSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" ];
+    in {
+      nixosModules.musnix = import ./default.nix;
+      nixosModules.default = self.nixosModules.musnix;
+      checks = forAllSystems (system: let
+        checkArgs = {
+          pkgs = nixpkgs.legacyPackages.${system};
+          inherit self;
+        };
+      in {
+        default = import ./tests/default.nix checkArgs;
+      });
   };
 }

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -70,9 +70,11 @@ in {
       '';
     };
 
-    environment.systemPackages =
-      (if cfg.ffado.enable then [ pkgs.ffado ] else []) ++
-      (if cfg.rtcqs.enable then [ pkgs.rtcqs ] else []);
+    environment.systemPackages = let
+        rtcqs = pkgs.callPackage ../pkgs/rtcqs.nix {};
+      in
+        (if cfg.ffado.enable then [ pkgs.ffado ] else []) ++
+        (if cfg.rtcqs.enable then [ rtcqs ] else []);
 
     environment.variables = let
       makePluginPath = format:

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -85,12 +85,13 @@ in {
         ])
         + ":$HOME/.${format}";
     in {
+      CLAP_PATH   = lib.mkDefault (makePluginPath "clap");
       DSSI_PATH   = lib.mkDefault (makePluginPath "dssi");
       LADSPA_PATH = lib.mkDefault (makePluginPath "ladspa");
       LV2_PATH    = lib.mkDefault (makePluginPath "lv2");
       LXVST_PATH  = lib.mkDefault (makePluginPath "lxvst");
-      VST_PATH    = lib.mkDefault (makePluginPath "vst");
       VST3_PATH   = lib.mkDefault (makePluginPath "vst3");
+      VST_PATH    = lib.mkDefault (makePluginPath "vst");
     };
 
     powerManagement.cpuFreqGovernor = "performance";

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -30,6 +30,16 @@ in {
         If enabled, use the Free FireWire Audio Drivers (FFADO).
       '';
     };
+    rtcqs.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        If enabled, install the rtcqs command-line utility, which analyzes
+        the system and makes suggestions about what to change to make it more
+        audio-friendly.  See
+        https://wiki.linuxaudio.org/wiki/system_configuration#rtcqs
+      '';
+    };
     soundcardPciId = mkOption {
       type = types.str;
       default = "";
@@ -61,9 +71,8 @@ in {
     };
 
     environment.systemPackages =
-      if cfg.ffado.enable
-        then [ pkgs.ffado ]
-        else [];
+      (if cfg.ffado.enable then [ pkgs.ffado ] else []) ++
+      (if cfg.rtcqs.enable then [ pkgs.rtcqs ] else []);
 
     environment.variables = let
       makePluginPath = format:

--- a/overlay.nix
+++ b/overlay.nix
@@ -75,5 +75,6 @@ with lib;
   realtimePatches = callPackage ./pkgs/os-specific/linux/kernel/patches.nix {};
 
   rtirq = callPackage ./pkgs/os-specific/linux/rtirq {};
+  rtcqs = callPackage ./pkgs/rtcqs.nix {};
 
 }

--- a/overlay.nix
+++ b/overlay.nix
@@ -75,6 +75,5 @@ with lib;
   realtimePatches = callPackage ./pkgs/os-specific/linux/kernel/patches.nix {};
 
   rtirq = callPackage ./pkgs/os-specific/linux/rtirq {};
-  rtcqs = callPackage ./pkgs/rtcqs.nix {};
 
 }

--- a/pkgs/rtcqs.nix
+++ b/pkgs/rtcqs.nix
@@ -7,9 +7,11 @@ pkgs.python3.pkgs.buildPythonApplication rec {
     buildInputs = [
       pkgs.python3.pkgs.setuptools
     ];
+    propagatedBuildInputs = [
+      pkgs.python3.pkgs.pysimplegui
+    ];
     src = fetchPypi {
       inherit pname version;
       hash = "sha256-DfeV9kGhdMf6hZ1iNJ0L3HUn7m8c1gRK5cjtJNUAvJI=";
     };
 }
-  

--- a/pkgs/rtcqs.nix
+++ b/pkgs/rtcqs.nix
@@ -4,12 +4,23 @@ pkgs.python3.pkgs.buildPythonApplication rec {
     pname = "rtcqs";
     version = "0.6.2";
     format = "pyproject";
+
+    # Dont check that the gui portion of the rtcqs package (rtcqs_gui) can be
+    # run. It uses PySimpleGUI, which, though it is available in nixpkgs,
+    # doesn't work properly.  It is a deliberately obfuscated commercial
+    # library, and isn't readily fixable.  rtcqs_gui offers no functionality
+    # that isn't offered by the command-line utility rtcqs.
+    #
+    # We set 'pythonRuntimeDepsCheck = "true"' in order to skip the Nix
+    # dependency checking that causes it to find a dependency on PySimpleGUI
+    # (run the UNIX "true" command rather than the default command), making
+    # the build complete rather than erroring out.
+    pythonRuntimeDepsCheckHook = "true";
+
     buildInputs = [
       pkgs.python3.pkgs.setuptools
     ];
-    propagatedBuildInputs = [
-      pkgs.python3.pkgs.pysimplegui
-    ];
+
     src = fetchPypi {
       inherit pname version;
       hash = "sha256-DfeV9kGhdMf6hZ1iNJ0L3HUn7m8c1gRK5cjtJNUAvJI=";

--- a/pkgs/rtcqs.nix
+++ b/pkgs/rtcqs.nix
@@ -1,0 +1,15 @@
+{pkgs, fetchPypi, ... }:
+
+pkgs.python3.pkgs.buildPythonApplication rec {
+    pname = "rtcqs";
+    version = "0.6.2";
+    format = "pyproject";
+    buildInputs = [
+      pkgs.python3.pkgs.setuptools
+    ];
+    src = fetchPypi {
+      inherit pname version;
+      hash = "sha256-DfeV9kGhdMf6hZ1iNJ0L3HUn7m8c1gRK5cjtJNUAvJI=";
+    };
+}
+  

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,10 +1,10 @@
 #
 # To run:
 #
-#    nix-build tests/default.nix
+#    nix flake check -L
 #
 
-import <nixpkgs/nixos/tests/make-test-python.nix> {
+(import ./lib.nix) {
   name = "musnix-boot";
 
   nodes.machine =

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -17,6 +17,7 @@
       musnix.rtirq.highList = "timer";
       musnix.soundcardPciId = "00:05.0";
       musnix.rtcqs.enable = true;
+      musnix.alsaSeq.enable = true;
     };
 
   testScript = builtins.readFile ./musnix-test.py;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -19,20 +19,5 @@ import <nixpkgs/nixos/tests/make-test-python.nix> {
       musnix.rtcqs.enable = true;
     };
 
-  testScript = ''
-    machine.start()
-    machine.wait_for_unit("multi-user.target")
-    result = machine.succeed("uname -v")
-    print(result)
-    if not "PREEMPT RT" or not "PREEMPT_RT" in result:
-        raise Exception("Wrong OS")
-    with subtest("rtcqs"):
-        machine.succeed("useradd -m musnix")
-        machine.succeed("usermod -a -G audio musnix")
-        result = machine.succeed("su - musnix -c rtcqs")
-        print(result)
-        if not "rtcqs - version" in result:
-            raise ValueError("rtcqs not installed")
-    print("PASSED")
-  '';
+  testScript = builtins.readFile ./musnix-test.py;
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -16,15 +16,23 @@ import <nixpkgs/nixos/tests/make-test-python.nix> {
       musnix.rtirq.enable = true;
       musnix.rtirq.highList = "timer";
       musnix.soundcardPciId = "00:05.0";
+      musnix.rtcqs.enable = true;
     };
 
   testScript = ''
     machine.start()
-    machine.wait_for_unit("default.target")
+    machine.wait_for_unit("multi-user.target")
     result = machine.succeed("uname -v")
     print(result)
     if not "PREEMPT RT" or not "PREEMPT_RT" in result:
         raise Exception("Wrong OS")
+    with subtest("rtcqs"):
+        machine.succeed("useradd -m musnix")
+        machine.succeed("usermod -a -G audio musnix")
+        result = machine.succeed("su - musnix -c rtcqs")
+        print(result)
+        if not "rtcqs - version" in result:
+            raise ValueError("rtcqs not installed")
     print("PASSED")
   '';
 }

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -1,0 +1,30 @@
+# see https://blog.thalheim.io/2023/01/08/how-to-use-nixos-testing-framework-with-flakes/
+
+# The first argument to this function is the test module itself
+test:
+
+# These arguments are provided by `flake.nix` on import, see checkArgs
+# Use "nix flake check -L" instead of "nix-build test/default.nix if you see this in an error
+{ pkgs, self}:
+
+let
+  inherit (pkgs) lib;
+
+  # this imports the nixos library that contains our testing framework
+  nixos-lib = import (pkgs.path + "/nixos/lib") {};
+in
+(nixos-lib.runTest {
+  hostPkgs = pkgs;
+
+  # This speeds up the evaluation by skipping evaluating documentation
+  # (optional)
+  defaults.documentation.enable = lib.mkDefault false;
+
+  # This makes `self` available in the NixOS configuration of our virtual
+  # machines. This is useful for referencing modules or packages from your own
+  # flake as well as importing from other flakes.
+  node.specialArgs = { inherit self; };
+
+  imports = [ test ];
+}).config.result
+

--- a/tests/musnix-test.py
+++ b/tests/musnix-test.py
@@ -37,4 +37,10 @@ with subtest("rtcqs"):
     if missed:
         raise ValueError(missed)
 
+with subtest("rtirq"):
+    result = machine.succeed("systemctl status rtirq")
+    print(result)
+    if not "Setting IRQ high-priorities: start [timer]" in result:
+        raise Exception("rtirq service set high priority to timer unsuccessful")
+
 print("PASSED")

--- a/tests/musnix-test.py
+++ b/tests/musnix-test.py
@@ -22,7 +22,7 @@ machine.wait_for_unit("multi-user.target")
 with subtest("preemptive-kernel"):
     result = machine.succeed("uname -v")
     print(result)
-    if not "PREEMPT RT" or not "PREEMPT_RT" in result:
+    if not "PREEMPT_RT" in result:
         raise Exception("Wrong OS")
 
 with subtest("swappiness"):

--- a/tests/musnix-test.py
+++ b/tests/musnix-test.py
@@ -35,7 +35,7 @@ with subtest("rtcqs"):
         if not line in result:
             missed.append(line)
     if missed:
-        raise ValueError(missed)
+        raise Exception(missed)
 
 with subtest("rtirq"):
     result = machine.succeed("systemctl status rtirq")

--- a/tests/musnix-test.py
+++ b/tests/musnix-test.py
@@ -13,8 +13,7 @@ rtcs_required = [
     "is using a tickless kernel",
     "is using threaded IRQs",
     "Realtime priorities can be set",
-# enable if https://github.com/musnix/musnix/pull/174 is merged
-#    "Power management can be controlled from user space",
+    "Power management can be controlled from user space",
 ]
 
 machine.start()

--- a/tests/musnix-test.py
+++ b/tests/musnix-test.py
@@ -1,0 +1,41 @@
+# this hair is here to appease my editor's pyflakes checks for undeclared names
+appease_pyflakes = vars()
+machine = appease_pyflakes['machine']
+subtest = appease_pyflakes['subtest']
+# end hair
+
+rtcs_required = [
+    "Not running as root",
+    "User musnix is member of a group that has sufficient rtprio",
+    "The scaling governor of all CPUs is set to performance",
+    "Valid kernel configuration found",
+    "High resolution timers are enabled",
+    "is using a tickless kernel",
+    "is using threaded IRQs",
+    "Realtime priorities can be set",
+# enable if https://github.com/musnix/musnix/pull/174 is merged
+#    "Power management can be controlled from user space",
+]
+
+machine.start()
+machine.wait_for_unit("multi-user.target")
+
+with subtest("preemptive-kernel"):
+    result = machine.succeed("uname -v")
+    print(result)
+    if not "PREEMPT RT" or not "PREEMPT_RT" in result:
+        raise Exception("Wrong OS")
+
+with subtest("rtcqs"):
+    machine.succeed("useradd -m musnix")
+    machine.succeed("usermod -a -G audio musnix")
+    result = machine.succeed("su - musnix -c rtcqs")
+    print(result)
+    missed = []
+    for line in rtcs_required:
+        if not line in result:
+            missed.append(line)
+    if missed:
+        raise ValueError(missed)
+
+print("PASSED")


### PR DESCRIPTION
I made this its own option, but I'd be ok with it if folks wanted to make it part of ``musnix.enable``.

One thing this helps with is detecting problems with config in the test.  It currently exposes a missing udev rule, which I hope to supply a fix for in an additional PR.