### PR TITLE
add udev rule to allow users in the audio group to change cpu dma latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ As an alternative to the above approaches, you can also add musnix as a flake:
     ```
     KERNEL=="rtc0", GROUP="audio"
     KERNEL=="hpet", GROUP="audio"
+    DEVPATH=="/devices/virtual/misc/cpu_dma_latency", OWNER="root", GROUP="audio", MODE="0660"
     ```
 
   * Set the following PAM limits:

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -99,6 +99,7 @@ in {
       extraRules = ''
         KERNEL=="rtc0", GROUP="audio"
         KERNEL=="hpet", GROUP="audio"
+        DEVPATH=="/devices/virtual/misc/cpu_dma_latency", OWNER="root", GROUP="audio", MODE="0660"
       '';
     };
   };


### PR DESCRIPTION
Enables DAWs like Ardour and Reaper to set CPU DMA latency, found via "rtcqs".