### PR TITLE
Use flake check for tests

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -9,6 +9,8 @@ jobs:
     - uses: jlumbroso/free-disk-space@main
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v26
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable      
     - run: nix build --dry-run --file release.nix
     - run: nix flake check -L
 

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -6,9 +6,10 @@ jobs:
   evaluate:
     runs-on: ubuntu-latest
     steps:
+    - uses: jlumbroso/free-disk-space@main
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v18
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - run: nix-build --dry-run release.nix
-    - run: nix flake check
+    - run: nix flake check -L

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -7,9 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: jlumbroso/free-disk-space@main
-    - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v18
-      with:
-        nix_path: nixpkgs=channel:nixos-unstable
-    - run: nix-build --dry-run release.nix
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v26
+    - run: nix build --dry-run --file release.nix
     - run: nix flake check -L
+
+# potential improvements:
+#   - populate a Cachix cache with realtime kernels (speed/disk space)
+#   - figure out the purpose of "nix build --dry-run --file release.nix"

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1690272529,
-        "narHash": "sha256-MakzcKXEdv/I4qJUtq/k/eG+rVmyOZLnYNC2w1mB59Y=",
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ef99fa5c5ed624460217c31ac4271cfb5cb2502c",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,18 @@
 {
   description = "Real-time audio in NixOS";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-  outputs = { self, nixpkgs }: {
-    nixosModules.musnix = import ./default.nix;
-    nixosModules.default = self.nixosModules.musnix;
+  outputs = { self, nixpkgs }: let
+      forAllSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" "aarch64-linux" ];
+    in {
+      nixosModules.musnix = import ./default.nix;
+      nixosModules.default = self.nixosModules.musnix;
+      checks = forAllSystems (system: let
+        checkArgs = {
+          pkgs = nixpkgs.legacyPackages.${system};
+          inherit self;
+        };
+      in {
+        default = import ./tests/default.nix checkArgs;
+      });
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Real-time audio in NixOS";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   outputs = { self, nixpkgs }: let
-      forAllSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" "aarch64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" ];
     in {
       nixosModules.musnix = import ./default.nix;
       nixosModules.default = self.nixosModules.musnix;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,10 +1,10 @@
 #
 # To run:
 #
-#    nix-build tests/default.nix
+#    nix flake check -L
 #
 
-import <nixpkgs/nixos/tests/make-test-python.nix> {
+(import ./lib.nix) {
   name = "musnix-boot";
 
   nodes.machine =

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -4,6 +4,7 @@
 test:
 
 # These arguments are provided by `flake.nix` on import, see checkArgs
+# Use "nix flake check -L" instead of "nix-build test/default.nix if you see this in an error
 { pkgs, self}:
 
 let

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -1,0 +1,29 @@
+# see https://blog.thalheim.io/2023/01/08/how-to-use-nixos-testing-framework-with-flakes/
+
+# The first argument to this function is the test module itself
+test:
+
+# These arguments are provided by `flake.nix` on import, see checkArgs
+{ pkgs, self}:
+
+let
+  inherit (pkgs) lib;
+
+  # this imports the nixos library that contains our testing framework
+  nixos-lib = import (pkgs.path + "/nixos/lib") {};
+in
+(nixos-lib.runTest {
+  hostPkgs = pkgs;
+
+  # This speeds up the evaluation by skipping evaluating documentation
+  # (optional)
+  defaults.documentation.enable = lib.mkDefault false;
+
+  # This makes `self` available in the NixOS configuration of our virtual
+  # machines. This is useful for referencing modules or packages from your own
+  # flake as well as importing from other flakes.
+  node.specialArgs = { inherit self; };
+
+  imports = [ test ];
+}).config.result
+


### PR DESCRIPTION
As mentioned in #173 this is a way to allow tests to be run that do not depend on the version of nixpkgs being used locally.

It changes the test regime such that it suggests running `nix flake check -L` instead of `nix-build tests/default.nix`.  This means that the version of nixpkgs used during testing will be the one in `flake.lock`, and the nixpkgs version of the host becomes irrelevant.  It will require that the test-running-system has a Nix configuration that enables flakes.

This PR also updates the `flake.lock` file because the old lockfile pointed at a version of nixpkgs that could not build the newer musnix realtime kernel successfully.

EDIT: note that the changes in this PR also causes every other PR and push to run the musnix tests; this may or may not be desirable.