### PR TITLE
Add rtcqs to flake packages output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,5 +14,8 @@
       in {
         default = import ./tests/default.nix checkArgs;
       });
+      packages = forAllSystems (platform: {
+        rtcqs = nixpkgs.legacyPackages.${platform}.callPackage ./pkgs/rtcqs.nix {};
+      });
   };
 }


### PR DESCRIPTION
I wanted to run `rtcqs` without having to install it. This allows nix (with flakes enabled) to get `rtcqs` via `nix run github:musnix/musnix#rtcqs`.