### PR TITLE
rtirq: cleanup, don't set phases, quote url, set pname

### DIFF
--- a/pkgs/os-specific/linux/rtirq/default.nix
+++ b/pkgs/os-specific/linux/rtirq/default.nix
@@ -1,17 +1,18 @@
 { stdenv, fetchurl, util-linux, lib }:
 
 stdenv.mkDerivation rec {
-  name = "rtirq";
+  pname = "rtirq";
   version = "20210309";
 
   src = fetchurl {
-    urls = ["http://www.rncbc.org/archive/${name}-${version}.tar.gz" "https://www.rncbc.org/archive/old/${name}-${version}.tar.gz" ];
+    urls = [
+      "http://www.rncbc.org/archive/rtirq-${version}.tar.gz"
+      "https://www.rncbc.org/archive/old/rtirq-${version}.tar.gz"
+    ];
     sha256 = "1z7nfak52g5zgahsdj2iz97q9pxjk2c3xhaa67c14xvzrnxvk0cq";
   };
 
-  phases = [ "unpackPhase" "patchPhase" "installPhase" ];
-
-  patchPhase = ''
+  postPatch = ''
     patchShebangs rtirq.sh
     substituteInPlace rtirq.sh \
       --replace "/sbin /usr/sbin /bin /usr/bin /usr/local/bin" "${util-linux}/bin"
@@ -24,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "IRQ thread tuning for realtime kernels";
-    homepage = http://www.rncbc.org/jack/;
+    homepage = "http://www.rncbc.org/jack/";
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ henrytill ];


### PR DESCRIPTION
Tested with ``nix-build -E 'with import <nixpkgs> {}; callPackage ./pkgs/os-specific/linux/rtirq {}'``