### PR TITLE
Add 6.9 kernel

### DIFF
--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -27,6 +27,7 @@ in {
         * pkgs.linuxPackages_6_1_rt
         * pkgs.linuxPackages_6_6_rt
         * pkgs.linuxPackages_6_8_rt
+        * pkgs.linuxPackages_6_9_rt
         or:
         * pkgs.linuxPackages_rt (currently pkgs.linuxPackages_6_6_rt)
         * pkgs.linuxPackages_latest_rt (currently pkgs.linuxPackages_6_8_rt)

--- a/overlay.nix
+++ b/overlay.nix
@@ -62,9 +62,18 @@ with lib;
     ];
   };
 
+  linux_6_9_rt = callPackage ./pkgs/os-specific/linux/kernel/linux-6.9-rt.nix {
+    kernelPatches = [
+      super.kernelPatches.bridge_stp_helper
+      super.kernelPatches.export-rt-sched-migrate
+      self.realtimePatches.realtimePatch_6_9
+    ];
+  };
+
   linuxPackages_6_1_rt  = recurseIntoAttrs (linuxPackagesFor self.linux_6_1_rt);
   linuxPackages_6_6_rt  = recurseIntoAttrs (linuxPackagesFor self.linux_6_6_rt);
   linuxPackages_6_8_rt  = recurseIntoAttrs (linuxPackagesFor self.linux_6_8_rt);
+  linuxPackages_6_9_rt  = recurseIntoAttrs (linuxPackagesFor self.linux_6_9_rt);
 
   linuxPackages_rt = self.linuxPackages_6_6_rt;
   linux_rt = self.linuxPackages_rt.kernel;

--- a/pkgs/os-specific/linux/kernel/linux-6.9-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-6.9-rt.nix
@@ -1,0 +1,14 @@
+{ fetchurl, buildLinuxRT, ... } @ args:
+let
+  metadata = (import ./metadata.nix).kernels."6.9";
+in
+buildLinuxRT (args // rec {
+  inherit (metadata) kversion pversion;
+  version = "${kversion}-${pversion}";
+  extraMeta.branch = metadata.branch;
+
+  src = fetchurl {
+    inherit (metadata) sha256;
+    url = "mirror://kernel/linux/kernel/v6.x/linux-${kversion}.tar.xz";
+  };
+} // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/metadata.nix
+++ b/pkgs/os-specific/linux/kernel/metadata.nix
@@ -35,4 +35,16 @@
     pversion = "rt11";
     sha256 = "0rchqyzxmvf1zpp5rndx9vxj7wbz424d4pvp5kfm1bw8aypkq1mh";
   };
+  kernels."6.9" = {
+    branch = "6.9";
+    kversion = "6.9";
+    pversion = "rt5";
+    sha256 = "0jc14s7z2581qgd82lww25p7c4w72scpf49z8ll3wylwk3xh3yi4";
+  };
+  patches."6.9" = {
+    branch = "6.9";
+    kversion = "6.9";
+    pversion = "rt5";
+    sha256 = "0sh5ajj8zm44l4dicyxy99g2fjp661i9jxilb94684cf8l39lwg1";
+  };
 }

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -21,4 +21,5 @@ in {
   realtimePatch_6_1  = realtimePatch metadata."6.1";
   realtimePatch_6_6  = realtimePatch metadata."6.6";
   realtimePatch_6_8  = realtimePatch metadata."6.8";
+  realtimePatch_6_9  = realtimePatch metadata."6.9";
 }

--- a/pkgs/os-specific/linux/kernel/update.sh
+++ b/pkgs/os-specific/linux/kernel/update.sh
@@ -5,7 +5,7 @@ set -o errexit
 set -o pipefail
 
 BRANCHES=(
-  "6.1" "6.6" "6.8"
+  "6.1" "6.6" "6.8" "6.9"
 )
 
 OUTPUT=metadata.nix


### PR DESCRIPTION
This adds 6.9.0 to the flake.

I'm unable to test this as I'm using ZFS on my system and 6.9.0 doesn't have zfs support yet in nixpkgs.

I can setup a test VM, which I will probably do regardless because I'd like to see it work. :-D