### PR TITLE
base.nix: use sessionVariables

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -86,7 +86,7 @@ in
       in
       (if cfg.ffado.enable then [ pkgs.ffado ] else [ ]) ++ (if cfg.rtcqs.enable then [ rtcqs ] else [ ]);
 
-    environment.variables =
+    environment.sessionVariables =
       let
         makePluginPath =
           format:


### PR DESCRIPTION
In graphical sessions, that are started from a login manager, `environment.variables` aren't loaded, but `environment.sessionVariables` are