### PR TITLE
add support for 6.11-rt7

### DIFF
--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -34,6 +34,7 @@ in
         * pkgs.linuxPackages_6_6_rt
         * pkgs.linuxPackages_6_8_rt
         * pkgs.linuxPackages_6_9_rt
+        * pkgs.linuxPackages_6_11_rt
         or:
         * pkgs.linuxPackages_rt (currently pkgs.linuxPackages_6_6_rt)
         * pkgs.linuxPackages_latest_rt (currently pkgs.linuxPackages_6_8_rt)

--- a/overlay.nix
+++ b/overlay.nix
@@ -93,15 +93,24 @@ with lib;
     ];
   };
 
-  linuxPackages_6_1_rt = recurseIntoAttrs (linuxPackagesFor self.linux_6_1_rt);
-  linuxPackages_6_6_rt = recurseIntoAttrs (linuxPackagesFor self.linux_6_6_rt);
-  linuxPackages_6_8_rt = recurseIntoAttrs (linuxPackagesFor self.linux_6_8_rt);
-  linuxPackages_6_9_rt = recurseIntoAttrs (linuxPackagesFor self.linux_6_9_rt);
+  linux_6_11_rt = callPackage ./pkgs/os-specific/linux/kernel/linux-6.11-rt.nix {
+    kernelPatches = [
+      super.kernelPatches.bridge_stp_helper
+      super.kernelPatches.export-rt-sched-migrate
+      self.realtimePatches.realtimePatch_6_11
+    ];
+  };
+
+  linuxPackages_6_1_rt  = recurseIntoAttrs (linuxPackagesFor self.linux_6_1_rt);
+  linuxPackages_6_6_rt  = recurseIntoAttrs (linuxPackagesFor self.linux_6_6_rt);
+  linuxPackages_6_8_rt  = recurseIntoAttrs (linuxPackagesFor self.linux_6_8_rt);
+  linuxPackages_6_9_rt  = recurseIntoAttrs (linuxPackagesFor self.linux_6_9_rt);
+  linuxPackages_6_11_rt = recurseIntoAttrs (linuxPackagesFor self.linux_6_11_rt);
 
   linuxPackages_rt = self.linuxPackages_6_6_rt;
   linux_rt = self.linuxPackages_rt.kernel;
 
-  linuxPackages_latest_rt = self.linuxPackages_6_8_rt;
+  linuxPackages_latest_rt = self.linuxPackages_6_11_rt;
   linux_latest_rt = self.linuxPackages_latest_rt.kernel;
 
   realtimePatches = callPackage ./pkgs/os-specific/linux/kernel/patches.nix { };

--- a/pkgs/os-specific/linux/kernel/linux-6.11-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-6.11-rt.nix
@@ -1,0 +1,18 @@
+{ fetchurl, buildLinuxRT, ... }@args:
+let
+  metadata = (import ./metadata.nix).kernels."6.11";
+in
+buildLinuxRT (
+  args
+  // rec {
+    inherit (metadata) kversion pversion;
+    version = "${kversion}-${pversion}";
+    extraMeta.branch = metadata.branch;
+
+    src = fetchurl {
+      inherit (metadata) sha256;
+      url = "mirror://kernel/linux/kernel/v6.x/linux-${kversion}.tar.xz";
+    };
+  }
+  // (args.argsOverride or { })
+)

--- a/pkgs/os-specific/linux/kernel/metadata.nix
+++ b/pkgs/os-specific/linux/kernel/metadata.nix
@@ -1,50 +1,19 @@
-{
-  kernels."6.1" = {
-    branch = "6.1";
-    kversion = "6.1.90";
-    pversion = "rt30";
-    sha256 = "07cfg0chssvpc4mqls3aln6s4lqjp6k4x2n63wndmkjgfqpdg8w3";
+let
+  kernel  = branch: kversion: pversion: sha256: { inherit branch kversion pversion sha256; };
+  patches = branch: kversion: pversion: sha256: { inherit branch kversion pversion sha256; };
+in {
+  kernels = {
+    "6.1"  = kernel "6.1"  "6.1.90" "rt30" "07cfg0chssvpc4mqls3aln6s4lqjp6k4x2n63wndmkjgfqpdg8w3";
+    "6.6"  = kernel "6.6"  "6.6.30" "rt30" "1ilwmgpgvddwkd9nx5999cb6z18scjyq7jklid26k1hg7f35nsmn";
+    "6.8"  = kernel "6.8"  "6.8.2"  "rt11" "013xs37cnan72baqvmn2qrcbs5bbcv1gaafrcx3a166gbgc25hws";
+    "6.9"  = kernel "6.9"  "6.9"    "rt5"  "0jc14s7z2581qgd82lww25p7c4w72scpf49z8ll3wylwk3xh3yi4";
+    "6.11" = kernel "6.11" "6.11"   "rt7"  "sha256-VdLGwCXrwngQx0jWYyXdW8YB6NMvhYHZ53ZzUpvayy4=";
   };
-  patches."6.1" = {
-    branch = "6.1";
-    kversion = "6.1.90";
-    pversion = "rt30";
-    sha256 = "0sgwxdy4bzjqr74nrmsyw1f2lcqpapxmkj5yywf7jkqa20jkdvgr";
-  };
-  kernels."6.6" = {
-    branch = "6.6";
-    kversion = "6.6.30";
-    pversion = "rt30";
-    sha256 = "1ilwmgpgvddwkd9nx5999cb6z18scjyq7jklid26k1hg7f35nsmn";
-  };
-  patches."6.6" = {
-    branch = "6.6";
-    kversion = "6.6.30";
-    pversion = "rt30";
-    sha256 = "05n6fyy5c0f18v4n1rfkcvqj8s0p5x6s16qq5mnmya86rhdr6gn7";
-  };
-  kernels."6.8" = {
-    branch = "6.8";
-    kversion = "6.8.2";
-    pversion = "rt11";
-    sha256 = "013xs37cnan72baqvmn2qrcbs5bbcv1gaafrcx3a166gbgc25hws";
-  };
-  patches."6.8" = {
-    branch = "6.8";
-    kversion = "6.8.2";
-    pversion = "rt11";
-    sha256 = "0rchqyzxmvf1zpp5rndx9vxj7wbz424d4pvp5kfm1bw8aypkq1mh";
-  };
-  kernels."6.9" = {
-    branch = "6.9";
-    kversion = "6.9";
-    pversion = "rt5";
-    sha256 = "0jc14s7z2581qgd82lww25p7c4w72scpf49z8ll3wylwk3xh3yi4";
-  };
-  patches."6.9" = {
-    branch = "6.9";
-    kversion = "6.9";
-    pversion = "rt5";
-    sha256 = "0sh5ajj8zm44l4dicyxy99g2fjp661i9jxilb94684cf8l39lwg1";
+  patches = {
+    "6.1"  = patches "6.1"  "6.1.90" "rt30" "0sgwxdy4bzjqr74nrmsyw1f2lcqpapxmkj5yywf7jkqa20jkdvgr";
+    "6.6"  = patches "6.6"  "6.6.30" "rt30" "05n6fyy5c0f18v4n1rfkcvqj8s0p5x6s16qq5mnmya86rhdr6gn7";
+    "6.8"  = patches "6.8"  "6.8.2"  "rt11" "0rchqyzxmvf1zpp5rndx9vxj7wbz424d4pvp5kfm1bw8aypkq1mh";
+    "6.9"  = patches "6.9"  "6.9"    "rt5"  "0sh5ajj8zm44l4dicyxy99g2fjp661i9jxilb94684cf8l39lwg1";
+    "6.11" = patches "6.11" "6.11"   "rt7"  "sha256-dFnNr2ssgoir8wbWYJ8EfkMYIb0hUDl0TS1+tQU1V/8=";
   };
 }

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -19,8 +19,9 @@ let
 
 in
 {
-  realtimePatch_6_1 = realtimePatch metadata."6.1";
-  realtimePatch_6_6 = realtimePatch metadata."6.6";
-  realtimePatch_6_8 = realtimePatch metadata."6.8";
-  realtimePatch_6_9 = realtimePatch metadata."6.9";
+  realtimePatch_6_1  = realtimePatch metadata."6.1";
+  realtimePatch_6_6  = realtimePatch metadata."6.6";
+  realtimePatch_6_8  = realtimePatch metadata."6.8";
+  realtimePatch_6_9  = realtimePatch metadata."6.9";
+  realtimePatch_6_11 = realtimePatch metadata."6.11";
 }


### PR DESCRIPTION
Currently compiling on my 7th gen Intel :hourglass_flowing_sand:

* Added definition for 6.11 kernel
* Added definition for 6.11-rt7 patches
* Turned `metadata.nix` into a "table" (sorry, couldn't help myself :grin:)

What I don't understand is why there are still separate RT patches provided at (https://cdn.kernel.org/pub/linux/kernel/projects/rt/6.11/), if RT support has been upstreamed? Perhaps someone here could enlighten me (xref https://github.com/musnix/musnix/issues/206)