### PR TITLE
Update environment variables base.nix

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -89,13 +89,13 @@ in
     environment.sessionVariables =
       let
         makePluginPath =
-          format:
+        format:
+          "$HOME/.${format}:" +
           (makeSearchPath format [
             "$HOME/.nix-profile/lib"
             "/run/current-system/sw/lib"
             "/etc/profiles/per-user/$USER/lib"
-          ])
-          + ":$HOME/.${format}";
+            ]);
       in
       {
         CLAP_PATH = lib.mkDefault (makePluginPath "clap");


### PR DESCRIPTION
Yabridge picks the first variable for clap plugins to store files. This changes the first variable to the user directory so that Yabridge can work as intended. Without this fix clap fails to sync/update installed plugins(borked).