### PR TITLE
Fix: Access recurseIntoAttrs from lib for nixpkgs-unstable compatibility

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -8,7 +8,8 @@ let
     linuxPackagesFor
     ;
 
-  recurseIntoAttrs = super.lib.recurseIntoAttrs;
+  # recurseIntoAttrs moved to lib in newer nixpkgs, fallback to top-level for older versions
+  recurseIntoAttrs = super.lib.recurseIntoAttrs or super.recurseIntoAttrs;
 
   # Since 20.09 this is a part of lib.kernel
   option = x: x // { optional = true; };


### PR DESCRIPTION
- Fixes overlay compatibility with current and older nixpkgs versions

- `recurseIntoAttrs` moved from top-level to lib in recent nixpkgs. In this PR we use a fallback pattern to support both locations for backward compatibility.

- Resolves "attribute 'recurseIntoAttrs' missing" error when using musnix with nixpkgs-unstable (post-August 2025) while maintaining compatibility with older stable releases.