### PR TITLE
vendor export-rt-sched-migrate.patch

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -66,7 +66,7 @@ with lib;
   linux_6_1_rt = callPackage ./pkgs/os-specific/linux/kernel/linux-6.1-rt.nix {
     kernelPatches = [
       super.kernelPatches.bridge_stp_helper
-      super.kernelPatches.export-rt-sched-migrate
+      self.realtimePatches.export-rt-sched-migrate
       self.realtimePatches.realtimePatch_6_1
     ];
   };
@@ -74,7 +74,7 @@ with lib;
   linux_6_6_rt = callPackage ./pkgs/os-specific/linux/kernel/linux-6.6-rt.nix {
     kernelPatches = [
       super.kernelPatches.bridge_stp_helper
-      super.kernelPatches.export-rt-sched-migrate
+      self.realtimePatches.export-rt-sched-migrate
       self.realtimePatches.realtimePatch_6_6
     ];
   };
@@ -82,7 +82,7 @@ with lib;
   linux_6_8_rt = callPackage ./pkgs/os-specific/linux/kernel/linux-6.8-rt.nix {
     kernelPatches = [
       super.kernelPatches.bridge_stp_helper
-      super.kernelPatches.export-rt-sched-migrate
+      self.realtimePatches.export-rt-sched-migrate
       self.realtimePatches.realtimePatch_6_8
     ];
   };
@@ -90,7 +90,7 @@ with lib;
   linux_6_9_rt = callPackage ./pkgs/os-specific/linux/kernel/linux-6.9-rt.nix {
     kernelPatches = [
       super.kernelPatches.bridge_stp_helper
-      super.kernelPatches.export-rt-sched-migrate
+      self.realtimePatches.export-rt-sched-migrate
       self.realtimePatches.realtimePatch_6_9
     ];
   };
@@ -98,7 +98,7 @@ with lib;
   linux_6_11_rt = callPackage ./pkgs/os-specific/linux/kernel/linux-6.11-rt.nix {
     kernelPatches = [
       super.kernelPatches.bridge_stp_helper
-      super.kernelPatches.export-rt-sched-migrate
+      self.realtimePatches.export-rt-sched-migrate
       self.realtimePatches.realtimePatch_6_11
     ];
   };

--- a/pkgs/os-specific/linux/kernel/export-rt-sched-migrate.patch
+++ b/pkgs/os-specific/linux/kernel/export-rt-sched-migrate.patch
@@ -1,0 +1,11 @@
+Export linux-rt (PREEMPT_RT) specific symbols needed by ZFS.
+(Regular kernel provides them static inline in linux/preempt.h.)
+
+--- a/kernel/sched/core.c
++++ b/kernel/sched/core.c
+@@ -1812 +1812 @@ void migrate_disable(void)
+-EXPORT_SYMBOL_GPL(migrate_disable);
++EXPORT_SYMBOL(migrate_disable);
+@@ -1843 +1843 @@ void migrate_enable(void)
+-EXPORT_SYMBOL_GPL(migrate_enable);
++EXPORT_SYMBOL(migrate_enable);

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -24,4 +24,9 @@ in
   realtimePatch_6_8  = realtimePatch metadata."6.8";
   realtimePatch_6_9  = realtimePatch metadata."6.9";
   realtimePatch_6_11 = realtimePatch metadata."6.11";
+
+  export-rt-sched-migrate = {
+    name = "export-rt-sched-migrate";
+    patch = ./export-rt-sched-migrate.patch;
+  };
 }


### PR DESCRIPTION
In NixOS/nixpkgs#502889, this patch was removed from upstream, so we are vendoring it to retain support for older kernels.